### PR TITLE
Update to viewDirective support non-child Dom element

### DIFF
--- a/src/viewDirective.js
+++ b/src/viewDirective.js
@@ -13,7 +13,8 @@ function $ViewDirective(   $state,   $compile,   $controller,   $anchorScroll) {
       // to derive our own qualified view name, then hang our own details
       // off the DOM so child directives can find it.
       var parent = element.parent().inheritedData('$uiView');
-      name  = name + '@' + (parent ? parent.state.name : '');
+      var parentStateName = attr.parentStateName || '';
+      name  = name + '@' + (parent ? parent.state.name : parentStateName);
       var view = { name: name, state: null };
       element.data('$uiView', view);
 


### PR DESCRIPTION
The current implementation force you to have the ui-view in a parent -> child relationship with your Dom structure. This was problematic for me as the parent view was receiving some CSS treatment ( 3D Transform ) that I didn't want the child-view to suffer from. Here is my experiment with the patch [Demo](http://dewmap.com/experiment/three-angular-02/index.html#/) Thank you for your hard work.
