### PR TITLE
Allow element and attr injections

### DIFF
--- a/src/viewDirective.js
+++ b/src/viewDirective.js
@@ -40,8 +40,12 @@ function $ViewDirective(   $state,   $compile,   $controller,   $anchorScroll) {
           viewScope = scope.$new();
           if (locals.$$controller) {
             locals.$scope = viewScope;
+            // This is a 'directive controller'. need to allow element and attr injections (TBD: transcludeFn)
+            locals.$element = element;
+            locals.$attrs = attr;
+            //store directive controller with distinct name on the element.data as per angular.js convention
             var controller = $controller(locals.$$controller, locals);
-            element.contents().data('$ngControllerController', controller);
+            element.data('$' + name+'Controller', controller);
           }
           link(viewScope);
           viewScope.$emit('$viewContentLoaded');


### PR DESCRIPTION
The controller in ui-router is really a 'directive controller' as it is tied with $ViewDirective. In Angular.js this type of controller is injectable with $element and $attr, so i've copied the same to here as well. 

 I needed it to manipulate the $element (specifically, for animation of the ui-view).
