### PR TITLE
Fixed a typo in the sample app's Index.html $urlRouterProvider

### DIFF
--- a/sample/index.html
+++ b/sample/index.html
@@ -50,7 +50,7 @@ angular.module('sample', ['ui.compat'])
     [        '$stateProvider', '$routeProvider', '$urlRouterProvider',
     function ($stateProvider,   $routeProvider,   $urlRouterProvider) {
       $urlRouterProvider
-        .when('/c?id', '/contacts/:id')
+        .when('/c:id', '/contacts/:id')
         .otherwise('/');
 
       $routeProvider


### PR DESCRIPTION
$urlRouterProvider.when('/c?id', '/contacts/:id') has an unintentional "?" instead of a ":".
