### PR TITLE
Wildcard matching option for query string parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 
 # webstorm files
 .idea
+*.iml

--- a/src/state.js
+++ b/src/state.js
@@ -178,7 +178,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       // But clear 'transition', as we still want to cancel any other pending transitions.
       // TODO: We may not want to bump 'transition' if we're called from a location change that we've initiated ourselves,
       // because we might accidentally abort a legitimate transition initiated from code?
-      if (to === from && locals === from.locals && to.params.indexOf('*') < 0) {
+      if (to === from && locals === from.locals) {
         $state.transition = null;
         return $q.when($state.current);
       }
@@ -287,12 +287,14 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       // we also need $stateParams to be available for any $injector calls we make during the
       // dependency resolution process.
       var $stateParams;
-      if (paramsAreFiltered && params['*'] === undefined) $stateParams = params;
+      if (paramsAreFiltered) $stateParams = params;
       else {
         $stateParams = {};
         forEach(state.params, function (name) {
           if(name === '*'){
-              // TODO ??? needed for transition but what...
+              for(var key in params){
+                  $stateParams[key] = params[key];
+              }
           } else {
             $stateParams[name] = params[name];
           }
@@ -355,6 +357,9 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
     }
 
     function equalForKeys(a, b, keys) {
+      if(keys.indexOf('*') > 0 && a != b){
+          return false;
+      }
       for (var i=0; i<keys.length; i++) {
         var k = keys[i];
         if (a[k] != b[k]) return false; // Not '===', values aren't necessarily normalized

--- a/src/state.js
+++ b/src/state.js
@@ -166,10 +166,12 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       var toPath = to.path,
           from = $state.$current, fromParams = $state.params, fromPath = from.path;
 
+      var reloadWild = ($state.current.reloadWild === undefined || $state.current.reloadWild);
+
       // Starting from the root of the path, keep all levels that haven't changed
       var keep, state, locals = root.locals, toLocals = [];
       for (keep = 0, state = toPath[keep];
-           state && state === fromPath[keep] && equalForKeys(toParams, fromParams, state.ownParams);
+           state && state === fromPath[keep] && equalForKeys(toParams, fromParams, state.ownParams, reloadWild);
            keep++, state = toPath[keep]) {
         locals = toLocals[keep] = state.locals;
       }
@@ -186,7 +188,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       var normalizedToParams = {};
       forEach(to.params, function (name) {
         if(name === '*'){
-          for(var key in toParams){
+          for(var key in toParams) {
             normalizedToParams[key] = toParams[key];
           }
         } else {
@@ -356,8 +358,8 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       });
     }
 
-    function equalForKeys(a, b, keys) {
-      if(keys.indexOf('*') > 0 && a != b){
+    function equalForKeys(a, b, keys, reloadWild) {
+      if(keys.indexOf('*') > 0 && a != b && reloadWild){
           return false;
       }
       for (var i=0; i<keys.length; i++) {

--- a/src/state.js
+++ b/src/state.js
@@ -178,16 +178,21 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       // But clear 'transition', as we still want to cancel any other pending transitions.
       // TODO: We may not want to bump 'transition' if we're called from a location change that we've initiated ourselves,
       // because we might accidentally abort a legitimate transition initiated from code?
-      if (to === from && locals === from.locals) {
+      if (to === from && locals === from.locals && to.params.indexOf('*') < 0) {
         $state.transition = null;
         return $q.when($state.current);
       }
-
       // Normalize/filter parameters before we pass them to event handlers etc.
       var normalizedToParams = {};
       forEach(to.params, function (name) {
-        var value = toParams[name];
-        normalizedToParams[name] = (value != null) ? String(value) : null;
+        if(name === '*'){
+          for(var key in toParams){
+            normalizedToParams[key] = toParams[key];
+          }
+        } else {
+          var value = toParams[name];
+          normalizedToParams[name] = (value != null) ? String(value) : null;
+        }
       });
       toParams = normalizedToParams;
 
@@ -282,11 +287,15 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       // we also need $stateParams to be available for any $injector calls we make during the
       // dependency resolution process.
       var $stateParams;
-      if (paramsAreFiltered) $stateParams = params;
+      if (paramsAreFiltered && params['*'] === undefined) $stateParams = params;
       else {
         $stateParams = {};
         forEach(state.params, function (name) {
-          $stateParams[name] = params[name];
+          if(name === '*'){
+              // TODO ??? needed for transition but what...
+          } else {
+            $stateParams[name] = params[name];
+          }
         });
       }
       var locals = { $stateParams: $stateParams };

--- a/src/urlMatcherFactory.js
+++ b/src/urlMatcherFactory.js
@@ -72,16 +72,6 @@ function UrlMatcher(pattern) {
     return string.replace(/[\\\[\]\^$*+?.()|{}]/g, "\\$&");
   }
 
-  this.parseUrlVars = function(varset) {
-    var vars = {}, hash;
-    var hashes = varset.substring(1).split('&');
-    for (var i = 0; i < hashes.length; i++) {
-      hash = hashes[i].split('=');
-      vars[hash[0]] = decodeURIComponent(hash[1]);
-    }
-    return vars;
-  };
-
   this.source = pattern;
 
   // Split into static segments separated by path parameter placeholders.
@@ -109,7 +99,6 @@ function UrlMatcher(pattern) {
     var searchString = search.substring(1);
     if(searchString === '*'){
       this.params.push('*');
-      compiled += '(\\?.*)?';
     } else {
       // Allow parameters to be separated by '?' as well as '&' to make concat() easier
       forEach(searchString.split(/[&?]/), addParameter);
@@ -181,9 +170,8 @@ UrlMatcher.prototype.exec = function (path, searchParams) {
   for (i=0; i<nPath; i++) values[params[i]] = decodeURIComponent(m[i+1]);
   for (/**/; i<nTotal; i++) {
       if(params[i] === '*'){
-        var urlVars = this.parseUrlVars(m[i+1]);
-        for(var key in urlVars){
-          values[key] = urlVars[key];
+        for(var key in searchParams){
+          values[key] = searchParams[key];
         }
       } else {
         values[params[i]] = searchParams[params[i]];

--- a/test/urlMatcherFactorySpec.js
+++ b/test/urlMatcherFactorySpec.js
@@ -30,7 +30,7 @@ describe("UrlMatcher", function () {
   it(".exec() captures parameter values from wildcard", function () {
     expect(
       new UrlMatcher('/users/:id/details/{type}/{repeat:[0-9]+}?*')
-        .exec('/users/123/details//0?match=&match2=wildcard', {}))
+        .exec('/users/123/details//0', {match: '', match2: 'wildcard'}))
       .toEqual({ id:'123', type:'', repeat:'0', match: '', match2: 'wildcard'});
   });
 

--- a/test/urlMatcherFactorySpec.js
+++ b/test/urlMatcherFactorySpec.js
@@ -27,6 +27,13 @@ describe("UrlMatcher", function () {
       .toEqual({ id:'123', type:'', repeat:'0' });
   });
 
+  it(".exec() captures parameter values from wildcard", function () {
+    expect(
+      new UrlMatcher('/users/:id/details/{type}/{repeat:[0-9]+}?*')
+        .exec('/users/123/details//0?match=&match2=wildcard', {}))
+      .toEqual({ id:'123', type:'', repeat:'0', match: '', match2: 'wildcard'});
+  });
+
   it(".exec() captures catch-all parameters", function () {
     var m = new UrlMatcher('/document/*path');
     expect(m.exec('/document/a/b/c', {})).toEqual({ path: 'a/b/c' });


### PR DESCRIPTION
This is a wildcard matching change so that /path/:to/:foo?\* is an acceptable url from the UrlMatcherFactory. If given this will match all query string parameters and pass that down to the state. This will also by default cause a reload. You can set the option in your state for reloadWild: false to disable the auto reload based on changes here. 

Please feel free to comment about what else you might like to see here as this meets my needs but I'm not sure it meets all needs that I've seen moving back and forth on this issues list. I'd be happy to update this for those needs or give someone else collaborator access to this branch if needed.
