### PR TITLE
add feature to clearAll and (re)initialize providers to support on-the-fly routing changes

### DIFF
--- a/src/compat.js
+++ b/src/compat.js
@@ -47,32 +47,9 @@ function $RouteProvider(  $stateProvider,    $urlRouterProvider) {
     return this;
   }
 
-  //initializes the routeProvider
-  var initialized = false;
-  function init() {
-    if (!initialized) {
-      $stateProvider.init();
-      $urlRouterProvider.init();
-      initialized = true;
-    }
-  }
-  this.init = function() { init(); return this;};
-
-  //clears the routeProvider and asks the stateProvider and urlRouterProvider
-  //to do the same
-  function clearAll() {
-    routes = [];
-    $stateProvider.clearAll();
-    $urlRouterProvider.clearAll();
-    initialized = false;
-  }
-  this.clearAll = function() { clearAll(); return this;};
-
   this.$get = $get;
   $get.$inject = ['$state', '$rootScope', '$routeParams'];
   function $get(   $state,   $rootScope,   $routeParams) {
-    //initialize the router(s)
-    init();
 
     var $route = {
       routes: routes,

--- a/src/state.js
+++ b/src/state.js
@@ -141,22 +141,10 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
   }
 
 
-  //initializes the urlRouterProvider
-  var initialized = false;
-  function init() {
-    if (!initialized) {
-      $urlRouterProvider.init();
-      initialized = true;
-    }
-  }
-  this.init = function() { init(); return this; };
-
-
   //clears all the states and the urlRouterProvider
   function clearAll() {
     states = {};
     $urlRouterProvider.clearAll();
-    initialized = false;
   }
   this.clearAll = function() { clearAll(); return this; };
 
@@ -164,8 +152,6 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
   this.$get = $get;
   $get.$inject = ['$rootScope', '$q', '$templateFactory', '$injector', '$stateParams', '$location', '$urlRouter'];
   function $get(   $rootScope,   $q,   $templateFactory,   $injector,   $stateParams,   $location,   $urlRouter) {
-    //initialize the router(s)
-    init();
 
     var TransitionSuperseded = $q.reject(new Error('transition superseded'));
     var TransitionPrevented = $q.reject(new Error('transition prevented'));

--- a/src/urlRouter.js
+++ b/src/urlRouter.js
@@ -83,33 +83,16 @@ function $UrlRouterProvider(  $urlMatcherFactory) {
       return this.rule(rule);
     };
 
-  //initializes the urlRouterProvider
-  var initialized = false;
-  function init() {
-    if (!initialized) {
-      if (otherwise) {
-        //there's an otherwise -- make it the last rule
-        rules.push(otherwise);
-      }
-      //
-      initialized = true;
-    }
-  }
-  this.init = function() {init(); return this;};
-
   //clears the rules and clears "otherwise" if it is defined
   function clearAll() {
     rules = [];
     otherwise = null;
-    initialized = false;
   }
   this.clearAll = function() {clearAll(); return this;};
 
   this.$get =
     [        '$location', '$rootScope', '$injector',
     function ($location,   $rootScope,   $injector) {
-      //initialize the router
-      init();
 
       // TODO: Optimize groups of rules with non-empty prefix into some sort of decision tree
       function update() {
@@ -119,6 +102,12 @@ function $UrlRouterProvider(  $urlMatcherFactory) {
           if (handled) {
             if (isString(handled)) $location.replace().url(handled);
             break;
+          }
+        }
+        if (!handled && otherwise) {
+          handled = otherwise($injector, $location);
+          if (handled) {
+            if (isString(handled)) $location.replace().url(handled);
           }
         }
       }

--- a/test/featureClearAllSpec.js
+++ b/test/featureClearAllSpec.js
@@ -1,7 +1,7 @@
-describe('clearAll/init feature', function () {
+describe('clearAll feature', function () {
 
   (function() {
-    //a simple runtime configurer that uses reset to redefine ui-router
+    //a simple runtime configurer that uses clearAll to redefine ui-router
     //behavior at *runtime* (as opposed to config time).
     //
     //A note about this provider/service
@@ -13,31 +13,17 @@ describe('clearAll/init feature', function () {
     //In other words -- the ui-router services *could*
     //do this themselves; the features of this "test" provider/service
     //may show up as a pull for ui-router seperately :)
-    //for now, clearAll and init allow what it does to be possible
-    angular.module('uiRouterRuntimeConfigurer', ['ui.compat']);
-    UiRouterRuntimeConfigProvider.$inject = ['$stateProvider', '$routeProvider', '$urlRouterProvider'];
-    function UiRouterRuntimeConfigProvider($stateProvider, $routeProvider, $urlRouterProvider) {
-
-      //can call init and clearAll on the stateProvider
-
-      function init() {
-        //the routeProvider inits states and urlRoutes too since it uses them
-        //hence this shortcut works
-        $routeProvider.init();
-      }
-      this.init = function() { init(); return this; };
+    //for now, clearAll allows what it does to be possible
+    angular.module('uiRouterRuntimeConfigurer', ['ui.state']);
+    UiRouterRuntimeConfigProvider.$inject = ['$stateProvider', '$urlRouterProvider'];
+    function UiRouterRuntimeConfigProvider($stateProvider, $urlRouterProvider) {
 
       function clearAll() {
-        //the routeProvider clears states and urlRoutes too since it uses them
+        //the stateProvider clears states and urlRoutes
         //hence this shortcut works
-        $routeProvider.clearAll();
+        $stateProvider.clearAll();
       }
       this.clearAll = function() { clearAll(); return this; };
-
-      function routeWhen(url, route) {
-        $routeProvider.when(url, route);
-      }
-      this.routeWhen = function(url, route) { routeWhen(url, route); return this; };
 
       function state(name, definition) {
         $stateProvider.state(name, definition);
@@ -45,28 +31,26 @@ describe('clearAll/init feature', function () {
       this.state = function(name, definition) { state(name, definition); return this; };
 
 
-      function urlWhen(what, handler) {
+      function when(what, handler) {
         $urlRouterProvider.when(what, handler);
       }
-      this.urlWhen = function(what, handler) { urlWhen(what, handler); return this; };
+      this.when = function(what, handler) { when(what, handler); return this; };
 
-      function urlOtherwise(rule) {
+      function otherwise(rule) {
         $urlRouterProvider.otherwise(rule);
       }
-      this.urlOtherwise = function(rule) { urlOtherwise(rule); return this; };
+      this.otherwise = function(rule) { otherwise(rule); return this; };
 
       this.$get = $get;
       function $get() {
         var uiRouterRuntimeConfig = {};
 
-        uiRouterRuntimeConfig.init = function() {init(); return this; };
         uiRouterRuntimeConfig.clearAll = function() { clearAll(); return this; };
-        uiRouterRuntimeConfig.routeWhen = function(url, route) { routeWhen(url, route); return this; };
         uiRouterRuntimeConfig.state = function(name, definition) { state(name, definition); return this; };
-        uiRouterRuntimeConfig.urlWhen = function(what, handler) { urlWhen(what, handler); return this; };
-        uiRouterRuntimeConfig.urlOtherwise = function(rule) { urlOtherwise(rule); return this; };
+        uiRouterRuntimeConfig.when = function(what, handler) { when(what, handler); return this; };
+        uiRouterRuntimeConfig.otherwise = function(rule) { otherwise(rule); return this; };
 
-        //this service can call clearAll and init from its provider
+        //this service can call the ui-router providers from its provider
         return uiRouterRuntimeConfig;
       }
     }
@@ -100,9 +84,9 @@ describe('clearAll/init feature', function () {
       .state('HOME', HOME)
       .state('FOUROHFOUR', FOUROHFOUR)
       .state('THEYWIN', THEYWIN)
-      .routeWhen('/northDakota', { redirectTo: '/about' } )
-      .urlWhen('/someoneGuessesThisUrl', '/theyWin' )
-      .urlOtherwise('/fourOhFour');
+      .when('/northDakota', '/about' )
+      .when('/someoneGuessesThisUrl', '/theyWin' )
+      .otherwise('/fourOhFour');
   }
 
   function configureAnon(uiRouterRuntimeConfigProviderOrService)
@@ -121,8 +105,6 @@ describe('clearAll/init feature', function () {
     ['uiRouterRuntimeConfigProvider',
       function(uiRouterRuntimeConfigProvider) {
         configureAnon(uiRouterRuntimeConfigProvider);
-        //no need to call init because we're working with the provider and
-        //the service will do it when it is instantiated
     }]
   );
 
@@ -161,7 +143,7 @@ describe('clearAll/init feature', function () {
       expect($state.current).toBe(FOUROHFOUR);
     }));
 
-    it('should support route/when', inject(function ($state, $rootScope, $q, $location) {
+    it('should support urlRouter/when', inject(function ($state, $rootScope, $q, $location) {
       $location.path("/northDakota");
       $rootScope.$apply();
       expect($state.current).toBe(ABOUT);
@@ -195,7 +177,6 @@ describe('clearAll/init feature', function () {
   describe('when the user logs in as admin', function() {
     it('the admin user will not have the login route but will have the admin route', inject(function (uiRouterRuntimeConfig, $state, $rootScope, $q, $location) {
       configureAdmin(uiRouterRuntimeConfig);
-      uiRouterRuntimeConfig.init();
       //this is kind of  dumb example because the admin should be able to change credentials but for demo purposes
       //this will have to do
       $location.path("/login");
@@ -212,7 +193,6 @@ describe('clearAll/init feature', function () {
       configureAdmin(uiRouterRuntimeConfig);
       var BLOG = {url: '/blog'};
       uiRouterRuntimeConfig.state('BLOG', BLOG);
-      uiRouterRuntimeConfig.init();
 
       //this is kind of  dumb example because the admin should be able to change credentials but for demo purposes
       //this will have to do


### PR DESCRIPTION
Background: it would be beneficial to be able to modify routing during runtime.  For example, when a user is logged into a system, the routes should be different than when the user is not logged in.  In another example, imagine a CMS.  The admin user can add a blog feature to the CMS.  In order to preview the blog, a new route should be defined so that the blog can be seen.  Other cases exist where the ability to define and undefine routes would be useful.

I looked at being able to modify routes/states on the fly in ui-router.  There are some challenges.

(1) It doesn't expose the route definition functions in the services.  This is easily surmountable.  In fact, this pull request contains a test spec that uses a service to access the providers.  So _no big deal there_, but it would be nice fold this into ui-router at some point.

(2) The ui.state and ui.compat modules do not keep track of the rules that are defined for them in urlRouter.  The challenge here is that if you want to pick out a state or a "route when" that you want to modify or remove, it would be unwieldy at best to edit the rules in the urlRouter accordingly.  It would be great if those two packages could track which rules go with which states and routes so that they could be modified or removed later.

(3) Related to challenge (2), the "otherwise" rule is appended to the end of the rules array when the urlRouter service starts.  This complicates one potential solution to (2), which would be to track the index position of the rule that relates to a state or when route.

So, in the long run, I'd like to solve these three challenges.  I hope that such a feature is welcome in ui-router and I'd appreciate some feedback on it.

In the short run, this pull request adds clearAll and init methods to the providers so that an app can wipe out the routes and redefine them.  Because the otherwise rule needs to remain last, the URL provider is very slightly modified to use init() when starting the service.

The test spec uses the technique of exposing the providers to a service so that they can be used at runtime.

Feedback is welcome.  I hope clearAll/init can be supported so that people will be able to use my larger project which is to manage both routes _and a generically applicable navigational UI directive_ in a datadriven manner.  More on that later.

Thanks!
