### PR TITLE
Allow url objects with signatures compatible with UrlMatcher to be executed from $UrlRouterProvider.when

### DIFF
--- a/src/urlRouter.js
+++ b/src/urlRouter.js
@@ -48,7 +48,9 @@ function $UrlRouterProvider(  $urlMatcherFactory) {
       if (isString(what))
           what = $urlMatcherFactory.compile(what);
 
-      if ($urlMatcherFactory.isMatcher(what)) {
+      /* use UrlMatcher (or compatible object) as is */
+      if (isObject(what) &&
+          isFunction(what.exec) && isFunction(what.format) && isFunction(what.concat)) {
         if (isString(handler)) {
           redirect = $urlMatcherFactory.compile(handler);
           handler = ['$match', function ($match) { return redirect.format($match); }];


### PR DESCRIPTION
$StateProvider.registerState allows url objects signature compatible with UrlMatcher to be used, but $UrlRouterProvider explicitly tests to see if the object type is UrlMatcher which means this functionality fails. This commit updates the logic in $UrlRouterProvider to use the same as in $StateProvider.
