### PR TITLE
Don't double-transition on child states with no URLs

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -111,7 +111,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
     // Register the state in the global state list and with $urlRouter if necessary.
     if (!state['abstract'] && url) {
       $urlRouterProvider.when(url, ['$match', function ($match) {
-        $state.transitionTo(state, $match, false);
+        if ($state.$current.navigable != state) $state.transitionTo(state, $match, false);
       }]);
     }
     states[name] = state;

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -38,7 +38,8 @@ describe('state', function () {
       .state('home.item', { url: "front/:id" })
       .state('about', { url: "/about" })
       .state('about.person', { url: "/:person" })
-      .state('about.person.item', { url: "/:id" });
+      .state('about.person.item', { url: "/:id" })
+      .state('about.sidebar', {});
 
     $provide.value('AppInjectable', AppInjectable);
   }));
@@ -160,7 +161,7 @@ describe('state', function () {
         '$stateChangeSuccess(C,A);');
     }));
 
-    it('aborts pending transitions even when going back to the curren state', inject(function ($state, $q) {
+    it('aborts pending transitions even when going back to the current state', inject(function ($state, $q) {
       initStateTo(A);
       logEvents = true;
 
@@ -190,6 +191,11 @@ describe('state', function () {
         'DD.onExit;' +
         'D.onExit;' +
         'A.onEnter;');
+    }));
+
+    it('doesn\'t transition to parent state when child has no URL', inject(function ($state, $q) {
+      $state.transitionTo('about.sidebar'); $q.flush();
+      expect($state.current.name).toEqual('about.sidebar');
     }));
   });
 


### PR DESCRIPTION
I found this issue while trying to finish up the `ui-sref` directive.

Basically, if a state has a URL, but a child state does not, it is impossible to transition to the child state, because the change in location will immediately trigger a second state transition to the parent. This fixes the issue by checking to see if the current state is a child of a state being targeted for transition based on a URL match.

Also fixes a typo in a test name. :-)
