### PR TITLE
fixed exception when no params passed with transitionTo and url has quer...

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -160,6 +160,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
 
     $state.transitionTo = function transitionTo(to, toParams, updateLocation) {
       if (!isDefined(updateLocation)) updateLocation = true;
+      if(!isDefined(toParams)) toParams = {};
 
       to = findState(to);
       if (to['abstract']) throw new Error("Cannot transition to abstract state '" + to + "'");


### PR DESCRIPTION
...y params

If url template has query params and query params are not passed with $state.transitionTo() then it throws undefined exception. Assign empty object to toParams if it is undefined
