### PR TITLE
UrlMatcher should throw error when route contains capture groups

### DIFF
--- a/src/urlMatcherFactory.js
+++ b/src/urlMatcherFactory.js
@@ -161,6 +161,8 @@ UrlMatcher.prototype.exec = function (path, searchParams) {
     nPath = this.segments.length-1,
     values = {}, i;
 
+  if (nPath !== m.length - 1) throw new Error("Unbalanced capture group in route '" + this.source + "'");
+
   for (i=0; i<nPath; i++) values[params[i]] = decodeURIComponent(m[i+1]);
   for (/**/; i<nTotal; i++) values[params[i]] = searchParams[params[i]];
 

--- a/test/urlMatcherFactorySpec.js
+++ b/test/urlMatcherFactorySpec.js
@@ -40,6 +40,28 @@ describe("UrlMatcher", function () {
       .toBeNull();
   });
 
+  it('.exec() throws on unbalanced capture list', function () {
+    var shouldThrow = {
+      "/url/{matchedParam:([a-z]+)}/child/{childParam}": '/url/someword/child/childParam',
+      "/url/{matchedParam:([a-z]+)}/child/{childParam}?foo": '/url/someword/child/childParam'
+    };
+
+    angular.forEach(shouldThrow, function(url, route) {
+      expect(function() { new UrlMatcher(route).exec(url, {}); }).toThrow(
+        "Unbalanced capture group in route '" + route + "'"
+      );
+    });
+
+    var shouldPass = {
+      "/url/{matchedParam:[a-z]+}/child/{childParam}": '/url/someword/child/childParam',
+      "/url/{matchedParam:[a-z]+}/child/{childParam}?foo": '/url/someword/child/childParam'
+    };
+
+    angular.forEach(shouldPass, function(url, route) {
+      expect(function() { new UrlMatcher(route).exec(url, {}); }).not.toThrow();
+    });
+  });
+
   it(".format() reconstitutes the URL", function () {
     expect(
       new UrlMatcher('/users/:id/details/{type}/{repeat:[0-9]+}?from')


### PR DESCRIPTION
As per #206, `UrlMatcher` does not allow capture groups in routes. This patch makes `UrlMatcher` check for unbalanced parameters and throw an error accordingly.

cc: @ksperling
