### PR TITLE
provide resolved dependencies to the $stateChangeSuccess event

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -763,7 +763,11 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
         location: true, inherit: false, relative: null, notify: true, reload: false, $retry: false
       }, options || {});
 
-      var from = $state.$current, fromParams = $state.params, fromPath = from.path;
+      var from         = $state.$current,
+          fromResolved = from.locals,
+          fromParams   = $state.params, 
+          fromPath     = from.path;
+
       var evt, toState = findState(to, options.relative);
 
       if (!isDefined(toState)) {
@@ -870,7 +874,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       // and return a promise for the new state. We also keep track of what the
       // current promise is, so that we can detect overlapping transitions and
       // keep only the outcome of the last transition.
-      var transition = $state.transition = resolved.then(function () {
+      var transition = $state.transition = resolved.then(function (toResolved) {
         var l, entering, exiting;
 
         if ($state.transition !== transition) return TransitionSuperseded;
@@ -924,7 +928,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
          * @param {State} fromState The current state, pre-transition.
          * @param {Object} fromParams The params supplied to the `fromState`.
          */
-          $rootScope.$broadcast('$stateChangeSuccess', to.self, toParams, from.self, fromParams);
+          $rootScope.$broadcast('$stateChangeSuccess', to.self, toParams, toResolved, from.self, fromParams, fromResolved);
         }
         $urlRouter.update(true);
 

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -11,6 +11,11 @@ describe('state', function () {
   function eventLogger(event, to, toParams, from, fromParams) {
     if (logEvents) log += event.name + '(' + to.name + ',' + from.name + ');';
   }
+
+  function eventLoggerSuccess(event, to, toParams, toResolved, from, fromParams, fromResolved) {
+    if (logEvents) log += event.name + '(' + to.name + ',' + from.name + ');';
+  }
+
   function callbackLogger(what) {
     return function () {
       if (logEnterExit) log += this.name + '.' + what + ';';
@@ -111,7 +116,7 @@ describe('state', function () {
     log = '';
     logEvents = logEnterExit = false;
     $rootScope.$on('$stateChangeStart', eventLogger);
-    $rootScope.$on('$stateChangeSuccess', eventLogger);
+    $rootScope.$on('$stateChangeSuccess', eventLoggerSuccess);
     $rootScope.$on('$stateChangeError', eventLogger);
     $rootScope.$on('$stateNotFound', eventLogger);
   }));
@@ -309,7 +314,7 @@ describe('state', function () {
     it('triggers $stateChangeSuccess', inject(function ($state, $q, $rootScope) {
       initStateTo(E, { i: 'iii' });
       var called;
-      $rootScope.$on('$stateChangeSuccess', function (ev, to, toParams, from, fromParams) {
+      $rootScope.$on('$stateChangeSuccess', function (ev, to, toParams, toResolved, from, fromParams, fromResolved) {
         expect(from).toBe(E);
         expect(fromParams).toEqual({ i: 'iii' });
         expect(to).toBe(D);


### PR DESCRIPTION
This commit adds a property `locals` to the state parameters of the `$stateChangeSuccess` event similar to the `locals` property for the parameters on the `$routeChangeSuccess` event on angular core.

Fixes #228
