### PR TITLE
Add transitionToParent() method

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -258,6 +258,10 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       return transition;
     };
 
+    $state.transitionToParent = function() {
+      return $state.transitionTo($state.$current.parent.self.name);
+    };
+
     $state.is = function (stateOrName) {
       return $state.$current === findState(stateOrName);
     };


### PR DESCRIPTION
I added a `transitionToParent()` method since I found this being a must-have method when doing nested states and views. Was doing some manual splitting and joining with `$state.current.name` before discovering `$state.$current.parent.self.name`, so I believe this is worth a public API and some documentation.

Actually, I think the name of the method is too verbose; I name it this way to make it looks like existing methods. It would be great if `transitionTo()` can simply be `to()` so this method can be called `toParent()`.
