### PR TITLE
Issue #345. Update sample.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,7 +70,13 @@ module.exports = function (grunt) {
       tasks: ['build', 'karma:background:run']
     },
     connect: {
-      server: {}
+      server: {},
+      sample: {
+        options:{
+          port: 5555,
+          keepalive: true
+        }
+      }
     },
   karma: {
     options: {
@@ -91,6 +97,7 @@ module.exports = function (grunt) {
   grunt.registerTask('dist', 'Perform a clean build and generate documentation', ['clean', 'build', 'jsdoc']);
   grunt.registerTask('release', 'Tag and perform a release', ['prepare-release', 'dist', 'perform-release']);
   grunt.registerTask('dev', 'Run dev server and watch for changes', ['build', 'connect', 'karma:background', 'watch']);
+  grunt.registerTask('sample', 'Run connect server with keepalive:true for sample app development', ['connect:sample']);
 
   grunt.registerTask('jsdoc', 'Generate documentation', function () {
     promising(this,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,15 @@
     "grunt-karma": "~0.4.3",
     "jsdoc": "git://github.com/jsdoc3/jsdoc.git#v3.1.1",
     "shelljs": "~0.1.4",
-    "faithful-exec": "~0.1.0"
+    "faithful-exec": "~0.1.0",
+    "karma-firefox-launcher": "~0.1.0",
+    "karma-chrome-launcher": "~0.1.0",
+    "karma-html2js-preprocessor": "~0.1.0",
+    "karma-jasmine": "~0.1.0",
+    "karma-requirejs": "~0.1.0",
+    "karma-script-launcher": "~0.1.0",
+    "karma-coffee-preprocessor": "~0.1.0",
+    "karma": "~0.10.1",
+    "karma-phantomjs-launcher": "~0.1.0"
   }
 }

--- a/sample/contacts.detail.html
+++ b/sample/contacts.detail.html
@@ -1,10 +1,13 @@
 <div>
   <h2>{{contact.name}}</h2>
-  <p class="muted">{{something}}</p>
   <ul>
     <li ng-repeat="item in contact.items">
-      <a href="#/contacts/{{contact.id}}/item/{{item.id}}">{{item.type}}</a>
+      <a ui-sref="contacts.detail.item({contactId:contact.id, itemId:item.id})">{{item.type}}</a>
     </li>
   </ul>
-  <div ui-view ng-animate="{enter:'fade-enter'}"></div>
+  <div ui-view ng-animate="{enter:'fade-enter'}">
+    <!-- Example of default content. This content will be replace as soon as
+         this ui-view is populate with a template -->
+    <small class="muted">Click on a contact item to view and/or edit it.</small>
+  </div>
 </div>

--- a/sample/contacts.html
+++ b/sample/contacts.html
@@ -2,16 +2,16 @@
   <div class="span3">
     <div class="pa-sidebar well well-small">
       <ul class="nav nav-list">
-        <li ng-class="{ active: $state.includes('contacts.list') }"><a href="#/contacts">All Contacts</a></li>
+        <li ng-class="{ active: $state.includes('contacts.list') }"><a ui-sref="contacts.list">All Contacts</a></li>
         <li class="nav-header">Top Contacts</li>
         <li ng-repeat="contact in contacts | limitTo:2"
             ng-class="{ active: $state.includes('contacts.detail') && $stateParams.contactId == contact.id }">
-          <a href="#/contacts/{{contact.id}}" >{{contact.name}}</a>
+          <a ui-sref="contacts.detail({contactId:contact.id})">{{contact.name}}</a>
         </li>
       </ul>
       <hr>
       <button class="btn" ng-click="goToRandom()">Show random contact</button>
-      <div ui-view="menu"></div>
+      <div ui-view="menuTip"></div>
     </div>
   </div>
   <div class="span9" ui-view ng-animate="{enter:'fade-enter'}"></div>

--- a/sample/contacts.json
+++ b/sample/contacts.json
@@ -1,0 +1,47 @@
+{
+  "contacts":[
+    {
+      "id": 1,
+      "name": "Alice",
+      "items": [
+        {
+          "id": "a",
+          "type": "phone number",
+          "value": "555-1234-1234"
+        },
+        {
+          "id": "b",
+          "type": "email",
+          "value": "alice@mailinator.com"
+        }
+      ]
+    },
+    {
+      "id": 42,
+      "name": "Bob",
+      "items": [
+        {
+          "id": "a",
+          "type": "blog",
+          "value": "http://bob.blogger.com"
+        },
+        {
+          "id": "b",
+          "type": "fax",
+          "value": "555-999-9999"
+        }
+      ]
+    },
+    {
+      "id": 123,
+      "name": "Eve",
+      "items": [
+        {
+          "id": "a",
+          "type": "full name",
+          "value": "Eve Adamsdottir"
+        }
+      ]
+    }
+  ]
+}

--- a/sample/contacts.list.html
+++ b/sample/contacts.list.html
@@ -1,6 +1,6 @@
 <h2>All Contacts</h2>
 <ul>
   <li ng-repeat="contact in contacts">
-    <a href="#/contacts/{{contact.id}}">{{contact.name}}</a>
+    <a ui-sref="contacts.detail({contactId:contact.id})">{{contact.name}}</a>
   </li>
 </ul>    

--- a/sample/empty.content.html
+++ b/sample/empty.content.html
@@ -1,3 +1,0 @@
-<h3>Current initial view title:</h3>
-<p><input type="text" ng-model="data.initialViewTitle"></p>
-<p><button class="btn" ng-click="showInitialView($event)">Back</button></p>

--- a/sample/empty.html
+++ b/sample/empty.html
@@ -1,5 +1,0 @@
-<div>This view contains a nested view below:</div>
-<div ui-view="emptycontent">
-	<h3>{{data.initialViewTitle}}</h3>
-	<p><button class="btn" ng-click="changeInitialViewTitle($event)">Change</button></p>
-</div>

--- a/sample/factory.js
+++ b/sample/factory.js
@@ -1,0 +1,45 @@
+angular.module('uiRouterSample')
+
+    // A RESTful factory for retreiving contacts from 'contacts.json'
+  .factory('contacts', ['$http', function ($http, utils) {
+    var path = 'contacts.json';
+    var contacts = $http.get(path).then(function (resp) {
+      return resp.data.contacts;
+    });
+
+    var factory = {};
+    factory.all = function () {
+      return contacts;
+    };
+    factory.get = function (id) {
+      return contacts.then(function(){
+        return utils.findById(contacts, id);
+      })
+    };
+    return factory;
+  }])
+
+  .factory('utils', function () {
+
+    return {
+
+      // Util for finding an object by its 'id' property among an array
+      findById: function findById(a, id) {
+        for (var i = 0; i < a.length; i++) {
+          if (a[i].id == id) return a[i];
+        }
+        return null;
+      },
+
+      // Util for returning a randomKey from a collection that also isn't the current key
+      newRandomKey: function newRandomKey(coll, key, currentKey){
+        var randKey;
+        do {
+          randKey = coll[Math.floor(coll.length * Math.random())][key];
+        } while (randKey == currentKey);
+        return randKey;
+      }
+
+    };
+
+  });

--- a/sample/index.html
+++ b/sample/index.html
@@ -1,232 +1,39 @@
 <!doctype html>
-<html lang="en" ng-app="sample"><head>
-  <meta charset="utf-8">
-  <link rel="stylesheet" type="text/css" href="bootstrap.min.css">
-  <style type="text/css">
-    .fade-enter-setup, .fade-leave-setup {
-      transition: opacity 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) 0s;
-    }
-    .fade-enter-setup,
-    .fade-leave-setup.fade-leave-start {
-      opacity: 0;
-    }
-    .fade-leave-setup,
-    .fade-enter-setup.fade-enter-start {
-      opacity: 1;
-    }
-  </style>
-  <script src="../lib/angular-1.1.4.js"></script>
-  <script src="../build/angular-ui-router.js"></script>
+<html lang="en" ng-app="uiRouterSample">
+  <head>
+    <meta charset="utf-8">
 
-  <!-- could easily use a custom property of the state here instead of 'name' -->
-  <title ng-bind="$state.current.name + ' - ui-router'">ui-router</title>
-</head><body>
-<div class="navbar navbar-fixed-top">
-  <div class="navbar-inner"><div class="container">
-    <a class="brand" href="#">ui-router</a>
-    <ul class="nav">
-      <li ng-class="{ active: $state.includes('contacts') }"><a href="#/contacts">Contacts</a></li>
-      <li ng-class="{ active: $state.includes('about') }"><a href="#/about">About</a></li>
-    </ul>
-    <p class="navbar-text pull-right" ui-view="hint"></p>
-  </div></div>
-</div>
-<div class="container" style="margin-top:60px" ui-view ng-animate="{enter:'fade-enter'}"></div>
-<hr>
-<pre>
-  $state = {{$state.current.name}}
-  $stateParams = {{$stateParams}}
-</pre>
-</body><script>
+    <link rel="stylesheet" type="text/css" href="bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="styles.css">
 
-function findById(a, id) {
-  for (var i=0; i<a.length; i++) {
-    if (a[i].id == id) return a[i];
-  }
-}
+    <script src="../lib/angular-1.1.4.js"></script>
+    <script src="../build/angular-ui-router.js"></script>
+    <script src="module.js"></script>
+    <script src="factory.js"></script>
+    <script src="states.js"></script>
 
-angular.module('sample', ['ui.router.compat'])
-  .config(
-    [        '$stateProvider', '$routeProvider', '$urlRouterProvider',
-    function ($stateProvider,   $routeProvider,   $urlRouterProvider) {
-      $urlRouterProvider
-        .when('/c?id', '/contacts/:id')
-        .otherwise('/');
-
-      $routeProvider
-        .when('/user/:id', {
-          redirectTo: '/contacts/:id',
-        })
-        .when('/', {
-          template: '<p class="lead">Welcome to the ngStates sample</p><p>Use the menu above to navigate</p>' +
-            '<p>Look at <a href="#/c?id=1">Alice</a> or <a href="#/user/42">Bob</a> to see a URL with a redirect in action.</p>',
-        });
-
-      $stateProvider
-        .state('contacts', {
-          url: '/contacts',
-          abstract: true,
-          templateUrl: 'contacts.html',
-          controller:
-            [        '$scope', '$state',
-            function ($scope,   $state) {
-              $scope.contacts = [{
-                id: 1,
-                name: "Alice",
-                items: [{
-                  id: 'a',
-                  type: 'phone number',
-                  value: '555-1234-1234',
-                },{
-                  id: 'b',
-                  type: 'email',
-                  value: 'alice@mailinator.com',
-                }],
-              }, {
-                id: 42,
-                name: "Bob",
-                items: [{
-                  id: 'a',
-                  type: 'blog',
-                  value: 'http://bob.blogger.com',
-                },{
-                  id: 'b',
-                  type: 'fax',
-                  value: '555-999-9999',
-                }],
-              }, {
-                id: 123,
-                name: "Eve",
-                items: [{
-                  id: 'a',
-                  type: 'full name',
-                  value: 'Eve Adamsdottir',
-                }],
-              }];
-
-              $scope.goToRandom = function () {
-                var contacts = $scope.contacts, id;
-                do {
-                  id = contacts[Math.floor(contacts.length * Math.random())].id;
-                } while (id == $state.params.contactId);
-                $state.transitionTo('contacts.detail', { contactId: id });
-              };
-            }],
-        })
-        .state('contacts.list', {
-          // parent: 'contacts',
-          url: '',
-          templateUrl: 'contacts.list.html',
-        })
-        .state('contacts.detail', {
-          // parent: 'contacts',
-          url: '/{contactId}',
-          resolve: {
-            something:
-              [        '$timeout', '$stateParams',
-              function ($timeout,   $stateParams) {
-                return $timeout(function () { return "Asynchronously resolved data (" + $stateParams.contactId + ")" }, 10);
-              }],
-          },
-          views: {
-            '': {
-              templateUrl: 'contacts.detail.html',
-              controller:
-                [        '$scope', '$stateParams', 'something',
-                function ($scope,   $stateParams,   something) {
-                  $scope.something = something;
-                  $scope.contact = findById($scope.contacts, $stateParams.contactId);
-                }],
-            },
-            'hint@': {
-              template: 'This is contacts.detail populating the view "hint@"',
-            },
-            'menu': {
-              templateProvider:
-                [ '$stateParams',
-                function ($stateParams){
-                  // This is just to demonstrate that $stateParams injection works for templateProvider
-                  // $stateParams are the parameters for the new state we're transitioning to, even
-                  // though the global '$stateParams' has not been updated yet.
-                  return '<hr><small class="muted">Contact ID: ' + $stateParams.contactId + '</small>';
-                }],
-            },
-          },
-        })
-        .state('contacts.detail.item', {
-          // parent: 'contacts.detail',
-          url: '/item/:itemId',
-          views: {
-            '': {
-              templateUrl: 'contacts.detail.item.html',
-              controller:
-                [        '$scope', '$stateParams', '$state',
-                function ($scope,   $stateParams,   $state) {
-                  $scope.item = findById($scope.contact.items, $stateParams.itemId);
-                  $scope.edit = function () {
-                    $state.transitionTo('contacts.detail.item.edit', $stateParams);
-                  };
-                }],
-            },
-            'hint@': {
-              template: 'Overriding the view "hint@"',
-            },
-          },
-        })
-        .state('contacts.detail.item.edit', {
-          views: {
-            '@contacts.detail': {
-              templateUrl: 'contacts.detail.item.edit.html',
-              controller:
-                [        '$scope', '$stateParams', '$state',
-                function ($scope,   $stateParams,   $state) {
-                  $scope.item = findById($scope.contact.items, $stateParams.itemId);
-                  $scope.done = function () {
-                    $state.transitionTo('contacts.detail.item', $stateParams);
-                  };
-                }],
-            },
-          },
-        })
-        .state('about', {
-          url: '/about',
-          templateProvider:
-            [        '$timeout',
-            function ($timeout) {
-              return $timeout(function () { return "Hello world" }, 100);
-            }],
-        })
-        .state('empty', {
-          url: '/empty',
-          templateUrl: 'empty.html',
-          controller:
-            [        '$scope', '$state',
-            function ($scope,   $state) {
-              // Using an object to access it via ng-model from child scope
-              $scope.data = {
-                initialViewTitle: "I am an initial view"
-              }
-              $scope.changeInitialViewTitle = function($event) {
-                $state.transitionTo('empty.emptycontent');
-              };
-              $scope.showInitialView = function($event) {
-                $state.transitionTo('empty');
-              };
-          }]
-        })
-        .state('empty.emptycontent', {
-          url: '/content',
-          views: {
-            'emptycontent': {
-              templateUrl: 'empty.content.html'
-            }
-          }
-        });
-    }])
-    .run(
-      [        '$rootScope', '$state', '$stateParams',
-      function ($rootScope,   $state,   $stateParams) {
-        $rootScope.$state = $state;
-        $rootScope.$stateParams = $stateParams;
-      }]);
-</script></html>
+    <!-- could easily use a custom property of the state here instead of 'name' -->
+    <title ng-bind="$state.current.name + ' - ui-router'">ui-router</title>
+  </head>
+  <body>
+    <div class="navbar navbar-fixed-top">
+      <div class="navbar-inner"><div class="container">
+        <a class="brand" ui-sref="home">ui-router</a>
+        <ul class="nav">
+          <li ng-class="{ active: $state.includes('contacts') }"><a ui-sref="contacts.list">Contacts</a></li>
+          <li ng-class="{ active: $state.includes('about') }"><a ui-sref="about">About</a></li>
+        </ul>
+        <p class="navbar-text pull-right" ui-view="hint"></p>
+      </div></div>
+    </div>
+    <div class="container" style="margin-top:60px" ui-view ng-animate="{enter:'fade-enter'}"></div>
+    <hr>
+    <pre>
+      $state = {{$state.current.name}}
+      $stateParams = {{$stateParams}}
+      $state full url = {{ $state.$current.url.source }}
+      <!-- $state.$current is not a public api, we are using it to
+           display the full url for learning purposes-->
+    </pre>
+  </body>
+</html>

--- a/sample/module.js
+++ b/sample/module.js
@@ -1,0 +1,13 @@
+// Make sure to include the `ui.router` module as a dependency
+angular.module('uiRouterSample', ['ui.router'])
+    .run(
+      [        '$rootScope', '$state', '$stateParams',
+      function ($rootScope,   $state,   $stateParams) {
+
+        // It's very handy to add references to $state and $stateParams to the $rootScope
+        // so that you can access them from any scope within your applications.For example,
+        // <li ng-class="{ active: $state.includes('contacts.list') }"> will set the <li>
+        // to active whenever 'contacts.list' or one of its decendents is active.
+        $rootScope.$state = $state;
+        $rootScope.$stateParams = $stateParams;
+      }]);

--- a/sample/states.js
+++ b/sample/states.js
@@ -1,0 +1,270 @@
+// Make sure to include the `ui.router` module as a dependency.
+angular.module('uiRouterSample')
+  .config(
+    [          '$stateProvider', '$urlRouterProvider',
+      function ($stateProvider,   $urlRouterProvider) {
+
+        /////////////////////////////
+        // Redirects and Otherwise //
+        /////////////////////////////
+
+        // Use $urlRouterProvider to configure any redirects (when) and invalid urls (otherwise).
+        $urlRouterProvider
+
+          // The `when` method says if the url is ever the 1st param, then redirect to the 2nd param
+          // Here we are just setting up some convenience urls.
+          .when('/c?id', '/contacts/:id')
+          .when('/user/:id', '/contacts/:id')
+
+          // If the url is ever invalid, e.g. '/asdf', then redirect to '/' aka the home state
+          .otherwise('/');
+
+
+        //////////////////////////
+        // State Configurations //
+        //////////////////////////
+
+        // Use $stateProvider to configure your states.
+        $stateProvider
+
+          //////////
+          // Home //
+          //////////
+
+          .state("home", {
+
+            // Use a url of "/" to set a states as the "index".
+            url: "/",
+
+            // Example of an inline template string. By default, templates
+            // will populate the ui-view within the parent state's template.
+            // For top level states, like this one, the parent template is
+            // the index.html file. So this template will be inserted into the
+            // ui-view within index.html.
+            template: '<p class="lead">Welcome to the UI-Router Demo</p>' +
+              '<p>Use the menu above to navigate. ' +
+              'Pay attention to the <code>$state</code> and <code>$stateParams</code> values below.</p>' +
+              '<p>Click these links—<a href="#/c?id=1">Alice</a> or ' +
+              '<a href="#/user/42">Bob</a>—to see a url redirect in action.</p>'
+
+          })
+
+          //////////////
+          // Contacts //
+          //////////////
+
+          .state('contacts', {
+
+            // With abstract set to true, that means this state can not be explicitly activated.
+            // It can only be implicitly activated by activating one if it's children.
+            abstract: true,
+
+            // This abstract state will prepend '/contacts' onto the urls of all its children.
+            url: '/contacts',
+
+            // Example of loading a template from a file. This is also a top level state,
+            // so this template file will be loaded and then inserted into the ui-view
+            // within index.html.
+            templateUrl: 'contacts.html',
+
+            // Use `resolve` to resolve any asynchronous controller dependencies
+            // *before* the controller is instantiated. In this case, since contacts
+            // returns a promise, the controller will wait until contacts.all() is
+            // resolved before instantiation. Non-promise return values are considered
+            // to be resolved immediately.
+            resolve: {
+              contacts: ['contacts',
+                function( contacts){
+                  return contacts.all();
+                }]
+            },
+
+            // You can pair a controller to your template. There *must* be a template to pair with.
+            controller: ['$scope', '$state', 'contacts', 'utils',
+              function (  $scope,   $state,   contacts,   utils) {
+
+                // Add a 'contacts' field in this abstract parent's scope, so that all
+                // child state views can access it in their scopes. Please note: scope
+                // inheritance is not due to nesting of states, but rather choosing to
+                // nest the templates of those states. It's normal scope inheritance.
+                $scope.contacts = contacts;
+
+                $scope.goToRandom = function () {
+                  var randId = utils.newRandomKey($scope.contacts, "id", $state.params.contactId);
+
+                  // $state.go() can be used as a high level convenience method
+                  // for activating a state programmatically.
+                  $state.go('contacts.detail', { contactId: randId });
+                };
+              }]
+          })
+
+          /////////////////////
+          // Contacts > List //
+          /////////////////////
+
+          // Using a '.' within a state name declares a child within a parent.
+          // So you have a new state 'list' within the parent 'contacts' state.
+          .state('contacts.list', {
+
+            // Using an empty url means that this child state will become active
+            // when its parent's url is navigated to. Urls of child states are
+            // automatically appended to the urls of their parent. So this state's
+            // url is '/contacts' (because '/contacts' + '').
+            url: '',
+
+            // IMPORTANT: Now we have a state that is not a top level state. Its
+            // template will be inserted into the ui-view within this state's
+            // parent's template; so the ui-view within contacts.html. This is the
+            // most important thing to remember about templates.
+            templateUrl: 'contacts.list.html'
+          })
+
+          ///////////////////////
+          // Contacts > Detail //
+          ///////////////////////
+
+          // You can have unlimited children within a state. Here is a second child
+          // state within the 'contacts' parent state.
+          .state('contacts.detail', {
+
+            // Urls can have parameters. They can be specified like :param or {param}.
+            // If {} is used, then you can also specify a regex pattern that the param
+            // must match. The regex is written after a colon (:). Note: Don't use capture
+            // groups in your regex patterns, because the whole regex is wrapped again
+            // behind the scenes. Our pattern below will only match numbers with a length
+            // between 1 and 4.
+
+            // Since this state is also a child of 'contacts' its url is appended as well.
+            // So its url will end up being '/contacts/{contactId:[0-9]{1,8}}'. When the
+            // url becomes something like '/contacts/42' then this state becomes active
+            // and the $stateParams object becomes { contactId: 42 }.
+            url: '/{contactId:[0-9]{1,4}}',
+
+            // If there is more than a single ui-view in the parent template, or you would
+            // like to target a ui-view from even higher up the state tree, you can use the
+            // views object to configure multiple views. Each view can get its own template,
+            // controller, and resolve data.
+
+            // View names can be relative or absolute. Relative view names do not use an '@'
+            // symbol. They always refer to views within this state's parent template.
+            // Absolute view names use a '@' symbol to distinguish the view and the state.
+            // So 'foo@bar' means the ui-view named 'foo' within the 'bar' state's template.
+            views: {
+
+              // So this one is targeting the unnamed view within the parent state's template.
+              '': {
+                templateUrl: 'contacts.detail.html',
+                controller: ['$scope', '$stateParams', 'utils',
+                  function (  $scope,   $stateParams,   utils) {
+                    $scope.contact = utils.findById($scope.contacts, $stateParams.contactId);
+                  }]
+              },
+
+              // This one is targeting the ui-view="hint" within the unnamed root, aka index.html.
+              // This shows off how you could populate *any* view within *any* ancestor state.
+              'hint@': {
+                template: 'This is contacts.detail populating the "hint" ui-view'
+              },
+
+              // This one is targeting the ui-view="menu" within the parent state's template.
+              'menuTip': {
+                // templateProvider is the final method for supplying a template.
+                // There is: template, templatUrl, and templateProvider.
+                templateProvider: ['$stateParams',
+                  function (        $stateParams) {
+                    // This is just to demonstrate that $stateParams injection works for templateProvider.
+                    // $stateParams are the parameters for the new state we're transitioning to, even
+                    // though the global '$stateParams' has not been updated yet.
+                    return '<hr><small class="muted">Contact ID: ' + $stateParams.contactId + '</small>';
+                  }]
+              }
+            }
+          })
+
+          //////////////////////////////
+          // Contacts > Detail > Item //
+          //////////////////////////////
+
+          .state('contacts.detail.item', {
+
+            // So following what we've learned, this state's full url will end up being
+            // '/contacts/{contactId}/item/:itemId'. We are using both types of parameters
+            // in the same url, but they behave identically.
+            url: '/item/:itemId',
+            views: {
+
+              // This is targeting the unnamed ui-view within the parent state 'contact.detail'
+              // We wouldn't have to do it this way if we didn't also want to set the 'hint' view below.
+              // We could instead just set templateUrl and controller outside of the view obj.
+              '': {
+                templateUrl: 'contacts.detail.item.html',
+                controller: ['$scope', '$stateParams', '$state', 'utils',
+                  function (  $scope,   $stateParams,   $state,   utils) {
+                    $scope.item = utils.findById($scope.contact.items, $stateParams.itemId);
+
+                    $scope.edit = function () {
+                      // Here we show off go's ability to navigate to a relative state. Using '^' to go upwards
+                      // and '.' to go down, you can navigate to any relative state (ancestor or descendant).
+                      // Here we are going down to the child state 'edit' (full name of 'contacts.detail.item.edit')
+                      $state.go('.edit', $stateParams);
+                    };
+                  }]
+              },
+
+              // Here we see we are overriding the template that was set by 'contact.detail'
+              'hint@': {
+                template: ' This is contacts.detail.item overriding the "hint" ui-view'
+              }
+            }
+          })
+
+          /////////////////////////////////////
+          // Contacts > Detail > Item > Edit //
+          /////////////////////////////////////
+
+          // Notice that this state has no 'url'. States do not require a url. You can use them
+          // simply to organize your application into "places" where each "place" can configure
+          // only what it needs. The only way to get to this state is via $state.go (or transitionTo)
+          .state('contacts.detail.item.edit', {
+            views: {
+
+              // This is targeting the unnamed view within the 'contact.detail' state
+              // essentially swapping out the template that 'contact.detail.item' had
+              // had inserted with this state's template.
+              '@contacts.detail': {
+                templateUrl: 'contacts.detail.item.edit.html',
+                controller: ['$scope', '$stateParams', '$state', 'utils',
+                  function (  $scope,   $stateParams,   $state,   utils) {
+                    $scope.item = utils.findById($scope.contact.items, $stateParams.itemId);
+                    $scope.done = function () {
+                      // Go back up. '^' means up one. '^.^' would be up twice, to the grandparent.
+                      $state.go('^', $stateParams);
+                    };
+                  }]
+              }
+            }
+          })
+
+          ///////////
+          // About //
+          ///////////
+
+          .state('about', {
+            url: '/about',
+
+            // Showing off how you could return a promise from templateProvider
+            templateProvider: ['$timeout',
+              function (        $timeout) {
+                return $timeout(function () {
+                  return '<p class="lead">UI-Router Resources</p><ul>' +
+                           '<li><a href="https://github.com/angular-ui/ui-router/tree/master/sample">Source for this Sample</a></li>' +
+                           '<li><a href="https://github.com/angular-ui/ui-router">Github Main Page</a></li>' +
+                           '<li><a href="https://github.com/angular-ui/ui-router#quick-start">Quick Start</a></li>' +
+                           '<li><a href="https://github.com/angular-ui/ui-router/wiki">In-Depth Guide</a></li>' +
+                           '<li><a href="https://github.com/angular-ui/ui-router/wiki/Quick-Reference">API Reference</a></li>' +
+                         '</ul>';
+                }, 100);
+              }]
+          })
+      }]);

--- a/sample/styles.css
+++ b/sample/styles.css
@@ -1,0 +1,11 @@
+.fade-enter-setup, .fade-leave-setup {
+  transition: opacity 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) 0s;
+}
+.fade-enter-setup,
+.fade-leave-setup.fade-leave-start {
+  opacity: 0;
+}
+.fade-leave-setup,
+.fade-enter-setup.fade-enter-start {
+  opacity: 1;
+}


### PR DESCRIPTION
- Use ui-router module, no compat
- Don't use $routeProvider, only use $urlRouterProvider
- Set up the index state '/' via a state config
- Split the index code into smaller files - states.js, styles.css, factory.js, contacts.json
- Use more best practices, e.g. loading contacts as json via $http, putting global utils into 'util' factory
- use ui-sref in templates
- Example of regex parameter
  Fixes #345. 
