### PR TITLE
0.2.0 not working in IE8 without es5-shim

### DIFF
--- a/src/resolve.js
+++ b/src/resolve.js
@@ -129,7 +129,7 @@ function $Resolve(  $q,    $injector) {
         }
         // Wait for any parameter that we have a promise for (either from parent or from this
         // resolve; in that case study() will have made sure it's ordered before us in the plan).
-        params.forEach(function (dep) {
+        forEach(params, function (dep) {
           if (promises.hasOwnProperty(dep) && !locals.hasOwnProperty(dep)) {
             waitParams++;
             promises[dep].then(function (result) {


### PR DESCRIPTION
It looks like most of the ui-router code uses angular.forEach, except for this one spot.
