### PR TITLE
Added option to replace previous browser history entry on transition

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -215,7 +215,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
     $state.transitionTo = function transitionTo(to, toParams, options) {
       if (!isDefined(options)) options = (options === true || options === false) ? { location: options } : {};
       toParams = toParams || {};
-      options = extend({ location: true, inherit: false, relative: null }, options);
+      options = extend({ location: true, inherit: false, relative: null, replacePreviousHistoryEntry: false }, options);
 
       var toState = findState(to, options.relative);
 
@@ -305,6 +305,9 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
         var toNav = to.navigable;
         if (options.location && toNav) {
           $location.url(toNav.url.format(toNav.locals.globals.$stateParams));
+          if (options.replacePreviousHistoryEntry) {
+             $location.replace();
+          }
         }
 
         $rootScope.$broadcast('$stateChangeSuccess', to.self, toParams, from.self, fromParams);

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -428,6 +428,38 @@ describe('state', function () {
       $rootScope.$apply();
       expect($state.current.name).toBe('');
     }));
+
+    it('should call $location.replace() to replace previous browser history entry when transitioning with "replacePreviousHistoryEntry" parameter true', inject(function ($state, $rootScope, $location, $q) {
+      var originalReplaceFn = $location.replace,
+          replaceWasCalled = false;
+
+      var decoratedReplaceFn = function() {
+          replaceWasCalled = true;
+          originalReplaceFn.call($location);
+      };
+      $location.replace = decoratedReplaceFn;
+
+      $state.transitionTo('about', {}, { replacePreviousHistoryEntry: true});
+      $q.flush();
+
+      expect(replaceWasCalled).toEqual(true);
+    }));
+
+    it('should NOT call $location.replace() to replace previous browser history entry when transitioning with default parameters', inject(function ($state, $rootScope, $location, $q) {
+      var originalReplaceFn = $location.replace,
+          replaceWasCalled = false;
+
+      var decoratedReplaceFn = function() {
+          replaceWasCalled = true;
+          originalReplaceFn.call($location);
+      };
+      $location.replace = decoratedReplaceFn;
+
+      $state.transitionTo('about');
+      $q.flush();
+
+      expect(replaceWasCalled).toEqual(false);
+    }));
   });
 
   describe('default properties', function() {


### PR DESCRIPTION
Added optional "replacePreviousHistoryEntry" parameter to state navigation options:
- if set to 'true' (default 'false') then the transition/navigation will replace the previous browser history entry
- if not set transition/navigation works as until now

A use-case for this would be when you have a state for an "add" screen and on "save" on that screen you navigate to a "details" state. However, if then the user goes back in the browser he'll end up on the "add" screen again, which might not be ideal: using this parameter as 'true' will cause the back navigation to actually go to the previous page (i.e. before the "add" screen).
