### PR TITLE
Add `$state.getAll()`

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -344,14 +344,13 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
     };
 
     $state.get = function (stateOrName) {
+      if (!isDefined(stateOrName)) {
+        var list = [];
+        forEach(states, function(state) { list.push(state.self); });
+        return list;
+      }
       var state = findState(stateOrName);
       return (state && state.self) ? state.self : null;
-    };
-
-    $state.getAll = function () {
-      var list = [];
-      forEach(states, function(state) { list.push(state.self); });
-      return list;
     };
 
     function resolveState(state, params, paramsAreFiltered, inherited, dst) {

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -395,7 +395,7 @@ describe('state', function () {
     }));
 
     it("should return all of the state's config", inject(function ($state) {
-      var list = $state.getAll().sort(function(a, b) { return (a.name > b.name) - (b.name > a.name); });
+      var list = $state.get().sort(function(a, b) { return (a.name > b.name) - (b.name > a.name); });
       var names = [
         '', // implicit root state
         'A',


### PR DESCRIPTION
`$state.get()` is insufficient for introspecting the entire state table, `getAll()` returns the entire table in one call (useful for debugging lazy-loaded states, for example).
