### PR TITLE
Added a $stateNotFound event which can prevent or redirect state transitions.

### DIFF
--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -208,6 +208,41 @@ describe('state', function () {
       expect($state.params).toEqual({ x: '1', y: '2', z: '3', w: '4' });
     }));
 
+    it('can defer a state transition in $stateNotFound', inject(function ($state, $q, $rootScope) {
+      initStateTo(A);
+      var called;
+      var deferred = $q.defer();
+      $rootScope.$on('$stateNotFound', function (ev, redirect) {
+        ev.retry = deferred.promise;
+        called = true;
+      });
+      var promise = $state.go('AA', { a: 1 });
+      stateProvider.state('AA', { parent: A, params: [ 'a' ]});
+      deferred.resolve();
+      $q.flush();
+      expect(called).toBeTruthy();
+      expect($state.current.name).toEqual('AA');
+      expect($state.params).toEqual({ a: '1' });
+    }));
+
+    it('can defer and supersede a state transition in $stateNotFound', inject(function ($state, $q, $rootScope) {
+      initStateTo(A);
+      var called;
+      var deferred = $q.defer();
+      $rootScope.$on('$stateNotFound', function (ev, redirect) {
+        ev.retry = deferred.promise;
+        called = true;
+      });
+      var promise = $state.go('AA', { a: 1 });
+      $state.go(B);
+      stateProvider.state('AA', { parent: A, params: [ 'a' ]});
+      deferred.resolve();
+      $q.flush();
+      expect(called).toBeTruthy();
+      expect($state.current).toEqual(B);
+      expect($state.params).toEqual({});
+    }));
+
     it('triggers $stateChangeSuccess', inject(function ($state, $q, $rootScope) {
       initStateTo(E, { i: 'iii' });
       var called;


### PR DESCRIPTION
Added a `$stateNotFound` event which can be prevented (in which case `transition aborted` is returned with no error thrown), or redirected by substituting the `redirect` event argument with the desired target state and params. In the latter case the state lookup is always retried once (even when not redirected), potentially allowing lazy-definition of state.

The `$stateNotFound` handler looks like:

```
$scope.$on('$stateNotFound', 
function(event, redirect, fromState, fromParams){ ... })
```

where `redirect` contains the original `to`, `toParams` and `options` arguments to `transitionTo`, allowing any/all of those arguments to be altered.
