### PR TITLE
Fixed 'No Such State - Undefined' error

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -137,7 +137,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
     }
     var state = states[name];
 
-    if (state && (isStr || (!isStr && (state === stateOrName || state.self === stateOrName.self)))) {
+    if (state && (isStr || (!isStr && (state === stateOrName || state.self === stateOrName || state.self === stateOrName.self)))) {
       return state;
     }
     return undefined;


### PR DESCRIPTION
Fixed this small bug.  All tests are passing.  I am not sure why, but it appears that the modified line wouldn't resolve properly when state.self (a state object) was equal to stateOrName.self (a state object) when it should have.
