### PR TITLE
ignoring bower_modules and fixing grunt dev task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 
 # common
 node_modules
+bower_components
 .DS_Store
 *~
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,7 +96,7 @@ module.exports = function (grunt) {
   grunt.registerTask('build', 'Perform a normal build', ['concat', 'uglify']);
   grunt.registerTask('dist', 'Perform a clean build and generate documentation', ['clean', 'build', 'jsdoc']);
   grunt.registerTask('release', 'Tag and perform a release', ['prepare-release', 'dist', 'perform-release']);
-  grunt.registerTask('dev', 'Run dev server and watch for changes', ['build', 'connect', 'karma:background', 'watch']);
+  grunt.registerTask('dev', 'Run dev server and watch for changes', ['build', 'connect:server', 'karma:background', 'watch']);
   grunt.registerTask('sample', 'Run connect server with keepalive:true for sample app development', ['connect:sample']);
 
   grunt.registerTask('jsdoc', 'Generate documentation', function () {


### PR DESCRIPTION
Development environment fixes. Git was not ignoring the bower download and the `grunt dev` task was getting stuck on the new connect:sample task and not getting to the watch.
