### PR TITLE
Add optional parameter matching to $state.is and $state.includes

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -377,14 +377,37 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
       return transition;
     };
 
-    $state.is = function is(stateOrName) {
+    $state.is = function is(stateOrName, params) {
       var state = findState(stateOrName);
-      return (isDefined(state)) ? $state.$current === state : undefined;
+
+      if (!isDefined(state)) {
+        return undefined;
+      }
+
+      if ($state.$current !== state) {
+        return false;
+      }
+
+      return isDefined(params) ? angular.equals($stateParams, params) : true;
     };
 
-    $state.includes = function includes(stateOrName) {
+    $state.includes = function includes(stateOrName, params) {
       var state = findState(stateOrName);
-      return (isDefined(state)) ? isDefined($state.$current.includes[state.name]) : undefined;
+      if (!isDefined(state)) {
+        return undefined;
+      }
+
+      if (!isDefined($state.$current.includes[state.name])) {
+        return false;
+      }
+
+      var validParams = true;
+      angular.forEach(params, function(value, key) {
+        if (!isDefined($stateParams[key]) || $stateParams[key] !== value) {
+          validParams = false;
+        }
+      });
+      return validParams;
     };
 
     $state.href = function href(stateOrName, params, options) {

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -393,6 +393,13 @@ describe('state', function () {
     it('should return undefined when queried state does not exist', inject(function ($state) {
       expect($state.is('Z')).toBeUndefined();
     }));
+
+    it('should return true when the current state is passed with matching parameters', inject(function ($state, $q) {
+      $state.transitionTo(D, {x: 'foo', y: 'bar'}); $q.flush();
+      expect($state.is(D, {x: 'foo', y: 'bar'})).toBe(true);
+      expect($state.is('D', {x: 'foo', y: 'bar'})).toBe(true);
+      expect($state.is(D, {x: 'bar', y: 'foo'})).toBe(false);
+    }));
   });
 
   describe('.includes()', function () {
@@ -411,7 +418,21 @@ describe('state', function () {
     }));
 
     it('should return undefined when queried state does not exist', inject(function ($state) {
-      expect($state.is('Z')).toBeUndefined();
+      expect($state.includes('Z')).toBeUndefined();
+    }));
+
+    it('should return true when the current state is passed with partial matching parameters', inject(function ($state, $q) {
+      $state.transitionTo(D, {x: 'foo', y: 'bar'}); $q.flush();
+      expect($state.includes(D, {x: 'foo'})).toBe(true);
+      expect($state.includes(D, {y: 'bar'})).toBe(true);
+      expect($state.includes('D', {x: 'foo'})).toBe(true);
+      expect($state.includes(D, {y: 'foo'})).toBe(false);
+    }));
+
+    it('should return true when the current state is passed with partial matching parameters from state\'s parent', inject(function ($state, $q) {
+      $state.transitionTo('about.person.item', {person: 'bob', id: 5}); $q.flush();
+      expect($state.includes('about.person', {person: 'bob'})).toBe(true);
+      expect($state.includes('about.person', {person: 'steve'})).toBe(false);
     }));
   });
 


### PR DESCRIPTION
Fixes #413.

Allows passing a second parameter to `$state.is` and `$state.includes` with parameters for the state. `is` will do a strict `angular.equals` on the passed parameters with the current `$stateParams`, while `includes` will only attempt to match the parameters given.

Examples:

```
{ active: $state.is('site.section', {siteId: site.id, sectionId: section.id)} }
```

```
{ active: $state.includes('site.section', {sectionId: section.id)} }
```

I also changed the method contract so it won't return `undefined` when a state doesn't exist. This didn't make sense to me that a function could return a boolean value, or `undefined`, especially when the docs state it will return a boolean.
