### PR TITLE
Component support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-karma');
-  
+
   // Project configuration.
   grunt.initConfig({
     builddir: 'build',
@@ -25,7 +25,12 @@ module.exports = function (grunt) {
     clean: [ '<%= builddir %>' ],
     concat: {
       options: {
-        banner: '<%= meta.banner %>\n(function (window, angular, undefined) {\n',
+        banner: '<%= meta.banner %>\n\n'+
+                '/* commonjs package manager support (eg componentjs) */\n'+
+                'if (module && exports && module.exports === exports){\n'+
+                '  module.exports = \'ui.router\';\n'+
+                '}\n\n'+
+                '(function (window, angular, undefined) {\n',
         footer: '})(window, window.angular);'
       },
       build: {
@@ -124,8 +129,10 @@ module.exports = function (grunt) {
 
   grunt.registerTask('prepare-release', function () {
     var bower = grunt.file.readJSON('bower.json'),
+        component = grunt.file.readJSON('component.json'),
         version = bower.version;
     if (version != grunt.config('pkg.version')) throw 'Version mismatch in bower.json';
+    if (version != component.version) throw 'Version mismatch in component.json';
 
     promising(this,
       ensureCleanMaster().then(function () {
@@ -144,7 +151,7 @@ module.exports = function (grunt) {
     var version = grunt.config('pkg.version'), releasedir = grunt.config('builddir');
     promising(this,
       system('git add \'' + releasedir + '\'').then(function () {
-        return system('git commit -m \'release ' + version + '\'');  
+        return system('git commit -m \'release ' + version + '\'');
       }).then(function () {
         return system('git tag \'' + version + '\'');
       })

--- a/README.md
+++ b/README.md
@@ -26,14 +26,15 @@ to change. Using it in a project that requires guaranteed stability is not recom
 
 ## Get Started
 
-**(1)** Get UI-Router in one of 3 ways:
+**(1)** Get UI-Router in one of 4 ways:
  - clone & [build](#developing) this repository
  - [download the release](http://angular-ui.github.io/ui-router/release/angular-ui-router.js) (or [minified](http://angular-ui.github.io/ui-router/release/angular-ui-router.min.js))
- - or via **[Bower](http://bower.io/)**: by running `$ bower install angular-ui-router` from your console
+ - via **[Bower](http://bower.io/)**: by running `$ bower install angular-ui-router` from your console
+ - or via **[Component](https://github.com/component/component)**: by running `$ component install angular-ui/ui-router` from your console
 
-**(2)** Include `angular-ui-router.js` (or `angular-ui-router.min.js`) in your `index.html`, after including Angular itself
+**(2)** Include `angular-ui-router.js` (or `angular-ui-router.min.js`) in your `index.html`, after including Angular itself (For Component users: ignore this step)
 
-**(3)** Add `'ui.router'` to your main module's list of dependencies
+**(3)** Add `'ui.router'` to your main module's list of dependencies (For Component users: replace `'ui.router'` with `require('angular-ui-router')`)
 
 When you're done, your setup should look similar to the following:
 
@@ -46,6 +47,8 @@ When you're done, your setup should look similar to the following:
     <script src="js/angular-ui-router.min.js"></script>
     <script>
         var myApp = angular.module('myApp', ['ui.router']);
+        // For Component users, it should look like this:
+        // var myApp = angular.module('myApp', [require('angular-ui-router')]);
     </script>
     ...
 </head>
@@ -271,4 +274,3 @@ There are a number of targets in the gruntfile that are used to generating diffe
 * `grunt build`: Perform a normal build
 * `grunt dist`: Perform a clean build and generate documentation
 * `grunt dev`: Run dev server (sample app) and watch for changes, builds and runs karma tests on changes.
-

--- a/component.json
+++ b/component.json
@@ -1,0 +1,16 @@
+{
+  "name": "angular-ui-router",
+  "version": "0.2.0",
+  "description": "State-based routing for AngularJS",
+  "keywords": [
+    "angular",
+    "states",
+    "routing"
+  ],
+  "main": "release/angular-ui-router.min.js",
+  "scripts": [
+    "release/angular-ui-router.min.js"
+  ],
+  "license": "MIT",
+  "repo": "angular-ui/ui-router"
+}


### PR DESCRIPTION
This adds support for [component](https://github.com/component/component) i.e.:

```
var foo = angular.module('foo', [
  require('angular-ui-router'),
  ...
```

I've updated:
- `grunt` `concat`'s "banner" to include code to support `commonjs`.
- `grunt` `prerelease` to ensure `component.version` is synced up.
- `readme.md` to include `component` instructions.

Let me know how to improve this or if its good to go. Note that I have not cut an actual release which appears to be something inappropriate to do myself.

Thanks.
