### PR TITLE
added absolute option to $state.href

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -411,14 +411,24 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
     };
 
     $state.href = function href(stateOrName, params, options) {
-      options = extend({ lossy: true, inherit: false, relative: $state.$current }, options || {});
+      options = extend({ lossy: true, inherit: false, absolute: false, relative: $state.$current }, options || {});
       var state = findState(stateOrName, options.relative);
       if (!isDefined(state)) return null;
 
       params = inheritParams($stateParams, params || {}, $state.$current, state);
       var nav = (state && options.lossy) ? state.navigable : state;
       var url = (nav && nav.url) ? nav.url.format(normalize(state.params, params || {})) : null;
-      return !$locationProvider.html5Mode() && url ? "#" + url : url;
+      if (!$locationProvider.html5Mode() && url) {
+        url = "#" + url;
+      }
+      if (options.absolute && url) {
+        url = $location.protocol() + '://' + 
+              $location.host() + 
+              ($location.port() == 80 || $location.port() == 443 ? '' : ':' + $location.port()) + 
+              (!$locationProvider.html5Mode() && url ? '/' : '') + 
+              url;
+      }
+      return url;
     };
 
     $state.get = function (stateOrName) {

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -510,6 +510,12 @@ describe('state', function () {
       expect($state.href("about.person", { person: "bob" })).toEqual("#/about/bob");
       expect($state.href("about.person.item", { person: "bob", id: null })).toEqual("#/about/bob/");
     }));
+    
+    it('generates absolute url when absolute is true', inject(function ($state) {
+      expect($state.href("about.sidebar", null, { absolute: true })).toEqual("http://server/#/about");
+      locationProvider.html5Mode(true);
+      expect($state.href("about.sidebar", null, { absolute: true })).toEqual("http://server/about");
+    }));
   });
 
   describe('.get()', function () {


### PR DESCRIPTION
For cases when we need full(absolute) url we can specify `absolute` option

``` javascript
$state.href('my.path', {}, { absolute: true }) // http://myserver.com/my/path
```
