### PR TITLE
Common JS package manager support breaks ui-router in browsers

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,7 +27,7 @@ module.exports = function (grunt) {
       options: {
         banner: '<%= meta.banner %>\n\n'+
                 '/* commonjs package manager support (eg componentjs) */\n'+
-                'if (module && exports && module.exports === exports){\n'+
+                'if (typeof module !== "undefined" && typeof exports !== "undefined" && module.exports === exports){\n'+
                 '  module.exports = \'ui.router\';\n'+
                 '}\n\n'+
                 '(function (window, angular, undefined) {\n',


### PR DESCRIPTION
I get the _Uncaught ReferenceError: module is not defined_ exception in Chrome and Firefox. The pull request fixes this problem.

It probably would be a good idea to run tests against the combined file, but it would require a substantial amount of work as quite a few of them currently fail if you make karma to run tests against build/angular-ui-router.js.
