### PR TITLE
Make .href() support .hashPrefix()

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -475,7 +475,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
       var nav = (state && options.lossy) ? state.navigable : state;
       var url = (nav && nav.url) ? nav.url.format(normalize(state.params, params || {})) : null;
       if (!$locationProvider.html5Mode() && url) {
-        url = "#" + url;
+        url = "#" + $locationProvider.hashPrefix() + url;
       }
       if (options.absolute && url) {
         url = $location.protocol() + '://' + 

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -613,6 +613,11 @@ describe('state', function () {
       locationProvider.html5Mode(true);
       expect($state.href("about.sidebar", null, { absolute: true })).toEqual("http://server/about");
     }));
+
+    it('respects $locationProvider.hashPrefix()', inject(function ($state) {
+      locationProvider.hashPrefix("!");
+      expect($state.href("home")).toEqual("#!/");
+    }));
   });
 
   describe('.get()', function () {


### PR DESCRIPTION
Google's AJAX crawling protocol requires a #! root instead of just at #. This is easy to accomplish using $locationProvider.hashPrefix("!"); however, ui-router's $state.href does not currently check the hash prefix.

To improve upon this commit, consider stashing the hash prefix just outside of $state.href's closure. That would be nice from a performance standpoint. I did not do that myself because hashPrefix would have to be set before ui-router is injected, and I'm not familiar enough with ui-router's codebase to understand the fix.
