### PR TITLE
Throw error when a resolve promise fails.

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -539,6 +539,8 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
       // Wait for all the promises and then return the activation object
       return $q.all(promises).then(function (values) {
         return dst;
+      }, function(error) {
+        throw new Error(error.message);
       });
     }
 


### PR DESCRIPTION
Dependency injection in my resolve maps was failing silently when I messed something up. This simply throws the error message to the console.
