### PR TITLE
Allow controller or controllerProvider to be/return a promise

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -524,15 +524,21 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
 
         promises.push($resolve.resolve(injectables, locals, dst.resolve, state).then(function (result) {
           // References to the controller (only instantiated at link time)
+          var controller;
           if (isFunction(view.controllerProvider) || isArray(view.controllerProvider)) {
             var injectLocals = angular.extend({}, injectables, locals);
-            result.$$controller = $injector.invoke(view.controllerProvider, null, injectLocals);
+            controller = $injector.invoke(view.controllerProvider, null, injectLocals);
           } else {
-            result.$$controller = view.controller;
+            controller = view.controller;
           }
-          // Provide access to the state itself for internal use
-          result.$$state = state;
-          dst[name] = result;
+
+          return $q.when(controller).then(function (resolvedController) {
+            result.$$controller = resolvedController;
+
+            // Provide access to the state itself for internal use
+            result.$$state = state;
+            dst[name] = result;
+          });
         }));
       });
 


### PR DESCRIPTION
I have a controllerProvider that needs to load a resource before it can determine which controller to use.  This commit understands promises as return values from controllerProviders, and, incidentally, from controllers.  

I understand that I could have worked around this with the resolve parameter, but this seemed a more natural way to declare my loading requirements. To use the resolve parameters, it was feeling like I had to basically inject a function that loaded the resources I need, determined the correct controller name, and then vacuously passed the controller name to the controllerProvider to be finally returned.  I can see it both ways and won't be offended if you all like requiring resolve.  Pretty nice to just slap a promise on the controller attribute though!

There is no test coverage yet, but I can work on changing that if this seems like a good direction to the main team. All of the existing tests pass.

Thanks for a great project - overall ui-router has felt like a complete and useful abstraction.
