### PR TITLE
throw error when angular-ui-router.js is loaded before angular.js

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -3,7 +3,7 @@
 'use strict';
 
 if(!angular.extend){
-    throw "Loaded asynchronously.  You must include load angular.js before angular-ui-router.js!";
+    throw "Cannot loaded asynchronously. You must load angular.js before angular-ui-router.js!";
 }
 
 var isDefined = angular.isDefined,


### PR DESCRIPTION
angular-ui-router.js cannot be loaded asynchronously with angular.  this change throws an error explaining such so that developers do not waste time trying to figure out what is meant by:

Error: [$injector:modulerr] Failed to instantiate module ui.router due to:
Error: [$injector:modulerr] Failed to instantiate module ui.router.state due to:
TypeError: undefined is not a function
