### PR TITLE
Expose `$urlRouterUpdateStart` event to allow deferrable `update()`

### DIFF
--- a/src/urlRouter.js
+++ b/src/urlRouter.js
@@ -92,7 +92,8 @@ function $UrlRouterProvider(  $urlMatcherFactory) {
     [        '$location', '$rootScope', '$injector',
     function ($location,   $rootScope,   $injector) {
       // TODO: Optimize groups of rules with non-empty prefix into some sort of decision tree
-      function update() {
+      function update(evt) {
+        if (evt && evt.defaultPrevented) return;
         function check(rule) {
           var handled = rule($injector, $location);
           if (handled) {
@@ -110,7 +111,12 @@ function $UrlRouterProvider(  $urlMatcherFactory) {
       }
 
       $rootScope.$on('$locationChangeSuccess', update);
-      return {};
+
+      return {
+        sync: function () {
+          update();
+        }
+      };
     }];
 }
 

--- a/test/urlRouterSpec.js
+++ b/test/urlRouterSpec.js
@@ -80,6 +80,32 @@ describe("UrlRouter", function () {
       expect(custom.url.format).not.toHaveBeenCalled();
       expect(custom.handler).toHaveBeenCalled();
     });
+
+    it('can be cancelled by preventDefault() in $locationChangeSuccess', inject(function () {
+      var called;
+      location.path("/baz");
+      scope.$on('$locationChangeSuccess', function (ev) {
+        ev.preventDefault();
+        called = true;
+      });
+      scope.$emit("$locationChangeSuccess");
+      expect(called).toBeTruthy();
+      expect(location.path()).toBe("/baz");
+    }));
+
+    it('can be deferred and updated in $locationChangeSuccess', inject(function ($urlRouter, $timeout) {
+      var called;
+      location.path("/baz");
+      scope.$on('$locationChangeSuccess', function (ev) {
+        ev.preventDefault();
+        called = true;
+        $timeout($urlRouter.sync, 2000);
+      });
+      scope.$emit("$locationChangeSuccess");
+      $timeout.flush();
+      expect(called).toBeTruthy();
+      expect(location.path()).toBe("/b4z");
+    }));
   });
 
 });


### PR DESCRIPTION
In many complex applications the first question that is asked is how can I asynchronously request user information before any `$stateChangeStart` events trigger. Whether it be to incorporate route protection, configuration, redirection etc.

This proposed pull request seeks to answer that question by exposing a new event `$urlRouterUpdateStart` which can cancel `$urlRouter#update()` with `preventDefault()`. `update()` is then referenced in the `$urlRouterUpdateStart` event listener and can be called asynchronously/synchronously.

The following example deferrers `update()` for 2000ms using `$timeout` asynchronously. The listener's deregistration function is assigned to `$off` and called when the listener is fired so that the listener will only defer `update()` once.

``` javascript
angular.module('app', ['ui.router']);
  .run(function($rootScope, $timeout) {
    var $off = $rootScope.$on('$urlRouterUpdateStart', function(evt, update) {
      evt.preventDefault();
      $timeout(update, 2000);
      $off();
    });
  });
```
