### PR TITLE
Support nested elements containing 'ui-sref'

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -54,7 +54,7 @@ function $StateRefDirective($state) {
 
       function getIsCurrentElClicked(e) {
         var targetEl = angular.element(e.target), srefEl = getSrefEl(targetEl);
-        return element[0] === sref[0];
+        return element[0] === srefEl[0];
       }
 
       element.bind("click", function(e) {


### PR DESCRIPTION
Stopped event-propagation in the click-handler for uiSref-directive to support nested tags with `ui-sref`-attribute.

```
<div ui-sref="root">
    Root-item description
    <div ui-sref="root.child">
        Child-detail
    </div>
</div>
```

Clicking the "Child-details"-link will fire the `root.child`-sref as expected, but also the `root`-sref immediately after, **resulting in the `root`-state always being shown**.
