### PR TITLE
Preserve url fragment on page reload

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -181,7 +181,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
     if (!state['abstract'] && state.url) {
       $urlRouterProvider.when(state.url, ['$match', '$stateParams', function ($match, $stateParams) {
         if ($state.$current.navigable != state || !equalForKeys($match, $stateParams)) {
-          $state.transitionTo(state, $match, false);
+          $state.transitionTo(state, $match, { location: false });
         }
       }]);
     }

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -689,6 +689,17 @@ describe('state', function () {
       expect($state.current.name).toBe('about.person');
     }));
 
+    it('preserve hash', inject(function($state, $rootScope, $location) {
+      $location.path("/about/bob");
+      $location.hash("frag");
+      $rootScope.$broadcast("$locationChangeSuccess");
+      $rootScope.$apply();
+      expect($state.params).toEqual({ person: "bob" });
+      expect($state.current.name).toBe('about.person');
+      expect($location.path()).toBe('/about/bob');
+      expect($location.hash()).toBe('frag');
+    }));
+
     it('should correctly handle absolute urls', inject(function ($state, $rootScope, $location) {
       $location.path("/first/subpath");
       $rootScope.$broadcast("$locationChangeSuccess");


### PR DESCRIPTION
This fixes a bug where the URL hash disappears when a page is first loaded.

For instance, if you had a link `<a href="#someanchor">link</a>` on your page and clicked on it, the link would work correctly (it would scroll to `#someanchor`), but if you copied and pasted the URL into a new tab and navigated to the page afresh, the hash would disappear and no scrolling would occur.

See also: https://github.com/angular-ui/ui-router/issues/510
