### PR TITLE
fix(uiSref): Add left-button detection support for IE8

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -46,7 +46,7 @@ function $StateRefDirective($state) {
       element.bind("click", function(e) {
         var button = e.which || e.button;
 
-        if ((button == 1) && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
+        if ((button === 0 || button == 1) && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
           scope.$evalAsync(function() {
             $state.go(ref.state, params, { relative: base });
           });


### PR DESCRIPTION
This fixes the left mouse button detection for IE8.

For reference, see [PPK - Which mouse button has been clicked](http://www.quirksmode.org/js/events_properties.html#button).
