### PR TITLE
Global filters for $state.is() / $state.includes()

### DIFF
--- a/config/karma.js
+++ b/config/karma.js
@@ -20,6 +20,7 @@ files = [
   'src/state.js',
   'src/viewDirective.js',
   'src/stateDirectives.js',
+  'src/stateFilters.js',
   'src/compat.js',
 
   'test/*Spec.js',

--- a/src/stateFilters.js
+++ b/src/stateFilters.js
@@ -1,0 +1,17 @@
+$IsStateFilter.$inject = ['$state'];
+function $IsStateFilter($state) {
+  return function(state) {
+    return $state.is(state);
+  };
+}
+
+$IncludedByStateFilter.$inject = ['$state'];
+function $IncludedByStateFilter($state) {
+  return function(state) {
+    return $state.includes(state);
+  };
+}
+
+angular.module('ui.router.state')
+  .filter('isState', $IsStateFilter)
+  .filter('includedByState', $IncludedByStateFilter);

--- a/test/stateFiltersSpec.js
+++ b/test/stateFiltersSpec.js
@@ -1,0 +1,48 @@
+describe('isState filter', function() {
+  beforeEach(module('ui.router'));
+  beforeEach(module(function($stateProvider) {
+    $stateProvider
+      .state('a', { url: '/' })
+      .state('a.b', { url: '/b' });
+  }));
+
+  it('should return true if the current state exactly matches the input state', inject(function($parse, $state, $q, $rootScope) {
+    $state.go('a');
+    $q.flush();
+    expect($parse('"a" | isState')($rootScope)).toBe(true);
+  }));
+
+  it('should return false if the current state does not exactly match the input state', inject(function($parse, $q, $state, $rootScope) {
+    $state.go('a.b');
+    $q.flush();
+    expect($parse('"a" | isState')($rootScope)).toBe(false);
+  }));
+});
+
+describe('includedByState filter', function() {
+  beforeEach(module('ui.router'));
+  beforeEach(module(function($stateProvider) {
+    $stateProvider
+      .state('a', { url: '/' })
+      .state('a.b', { url: '/b' })
+      .state('c', { url: '/c' });
+  }));
+
+  it('should return true if the current state exactly matches the input state', inject(function($parse, $state, $q, $rootScope) {
+    $state.go('a');
+    $q.flush();
+    expect($parse('"a" | includedByState')($rootScope)).toBe(true);
+  }));
+
+  it('should return true if the current state includes the input state', inject(function($parse, $state, $q, $rootScope) {
+    $state.go('a.b');
+    $q.flush();
+    expect($parse('"a" | includedByState')($rootScope)).toBe(true);
+  }));
+
+  it('should return false if the current state does not include input state', inject(function($parse, $state, $q, $rootScope) {
+    $state.go('c');
+    $q.flush();
+    expect($parse('"a" | includedByState')($rootScope)).toBe(false);
+  }));
+});


### PR DESCRIPTION
I keep running into people writing code like `ng-class="{active: currentState === 'foo.bar.baz'}`

It would be really cool if there were some filters provided to simplify this for people, and provided for more readable code, like `ng-class="{active: 'foo.bar.baz' | isCurrentState}` or something. (I realize fully well that linguistically, this looks weird --- but it's a bit clearer than the expression, IMO)

I'll take a few minutes today to write such filters, up to you whether you want to merge it, I suppose, knowing fully well that it is trivial for application developers to write these same things. It's just not clear to me why they so often choose not to!
