### PR TITLE
chore(grunt): adds grunt-conventional-changelog plugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,6 +8,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-karma');
+  grunt.loadNpmTasks('grunt-conventional-changelog');
 
   // Project configuration.
   grunt.initConfig({
@@ -83,18 +84,23 @@ module.exports = function (grunt) {
         }
       }
     },
-  karma: {
-    options: {
-      configFile: 'config/karma.js'
+    karma: {
+      options: {
+        configFile: 'config/karma.js'
+      },
+      unit: {
+        singleRun: true
+      },
+      background: {
+        background: true,
+        browsers: [ grunt.option('browser') || 'PhantomJS' ]
+      }
     },
-    unit: {
-      singleRun: true
-    },
-    background: {
-      background: true,
-      browsers: [ grunt.option('browser') || 'PhantomJS' ]
+    changelog: {
+      options: {
+        dest: 'CHANGELOG.md'
+      }
     }
-  }
   });
 
   grunt.registerTask('default', ['build', 'jshint', 'karma:unit']);

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "karma-script-launcher": "~0.1.0",
     "karma-coffee-preprocessor": "~0.1.0",
     "karma": "~0.10.1",
-    "karma-phantomjs-launcher": "~0.1.0"
+    "karma-phantomjs-launcher": "~0.1.0",
+    "grunt-conventional-changelog": "~1.0.0"
   }
 }


### PR DESCRIPTION
this plugin let's us autogenerate changelogs, all we have to do is to
follow the convetions this commit message follows

the angular.js project itself uses this convention too

we could then also somehow integrate the changelog task in one of the
release tasks
