### PR TITLE
Canonicalize state names

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -158,14 +158,30 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
       toString: function() { return this.name; }
     });
 
-    var name = state.name;
-    if (!isString(name) || name.indexOf('@') >= 0) throw new Error("State must have a valid name");
-    if (states.hasOwnProperty(name)) throw new Error("State '" + name + "'' is already defined");
+    var name = state.name,
+        parentName,
+        lastDot = name.lastIndexOf('.');
 
     // Get parent name
-    var parentName = (name.indexOf('.') !== -1) ? name.substring(0, name.lastIndexOf('.'))
-        : (isString(state.parent)) ? state.parent
-        : '';
+    if (lastDot !== -1) {
+      parentName = name.substring(0, lastDot);
+      name = name.substring(lastDot + 1);
+    } else if (isString(state.parent)) {
+      parentName = state.parent;
+    } else if (state.parent) {
+      parentName = state.parent.name;
+    } else {
+      parentName = null;
+    }
+
+    if (parentName) {
+      name = parentName + '.' + name;
+      state.name = name;
+      state.self.name = name;
+    }
+
+    if (!isString(name) || name.indexOf('@') >= 0) throw new Error("State must have a valid name");
+    if (states.hasOwnProperty(name)) throw new Error("State '" + name + "'' is already defined");
 
     // If parent is not registered yet, add state to queue and register later
     if (parentName && !states[parentName]) {
@@ -315,7 +331,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
         toState = findState(to, options.relative);
         if (!isDefined(toState)) {
           if (options.relative) throw new Error("Could not resolve '" + to + "' from state '" + options.relative + "'");
-          throw new Error("No such state '" + to + "'");
+          throw new Error("No such state " + JSON.stringify(to));
         }
       }
       if (toState[abstractKey]) throw new Error("Cannot transition to abstract state '" + to + "'");
@@ -479,10 +495,10 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
         url = "#" + $locationProvider.hashPrefix() + url;
       }
       if (options.absolute && url) {
-        url = $location.protocol() + '://' + 
-              $location.host() + 
-              ($location.port() == 80 || $location.port() == 443 ? '' : ':' + $location.port()) + 
-              (!$locationProvider.html5Mode() && url ? '/' : '') + 
+        url = $location.protocol() + '://' +
+              $location.host() +
+              ($location.port() == 80 || $location.port() == 443 ? '' : ':' + $location.port()) +
+              (!$locationProvider.html5Mode() && url ? '/' : '') +
               url;
       }
       return url;

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -13,7 +13,7 @@ describe('state', function () {
   }
   function callbackLogger(what) {
     return function () {
-      if (logEnterExit) log += this.name + '.' + what + ';';
+      if (logEnterExit) log += this.name + '!' + what + ';';
     };
   }
 
@@ -26,6 +26,10 @@ describe('state', function () {
       H = { data: {propA: 'propA', propB: 'propB'} },
       HH = { parent: H },
       HHH = {parent: HH, data: {propA: 'overriddenA', propC: 'propC'} },
+      I = { name: 'I' },
+      II = { name: 'II', parent: I },
+      J = {},
+      JJ = {},
       RS = { url: '^/search?term', reloadOnSearch: false },
       AppInjectable = {};
 
@@ -46,6 +50,10 @@ describe('state', function () {
       .state('H', H)
       .state('HH', HH)
       .state('HHH', HHH)
+      .state(I)
+      .state(II)
+      .state('J', J)
+      .state('J.JJ', JJ)
       .state('RS', RS)
 
       .state('home', { url: "/" })
@@ -152,7 +160,7 @@ describe('state', function () {
       });
       $q.flush();
       expect($location.search()).toEqual({term: 'hello'});
-      expect(called).toBeFalsy();        
+      expect(called).toBeFalsy();
     }));
 
     it('ignores non-applicable state parameters', inject(function ($state, $q) {
@@ -214,7 +222,7 @@ describe('state', function () {
         message = err.message;
       }
       $q.flush();
-      expect(message).toEqual('No such state \'never_defined\'');
+      expect(message).toEqual('No such state "never_defined"');
       expect(called).toBeTruthy();
       expect($state.current).toBe(E);
     }));
@@ -255,10 +263,10 @@ describe('state', function () {
         stateProvider.state(redirect.to, { parent: DD, params: [ 'x', 'y', 'z', 'w' ]});
         called = true;
       });
-      var promise = $state.go('DDD', { w: 4 });
+      var promise = $state.go('D.DD.DDD', { w: 4 });
       $q.flush();
       expect(called).toBeTruthy();
-      expect($state.current.name).toEqual('DDD');
+      expect($state.current.name).toEqual('D.DD.DDD');
       expect($state.params).toEqual({ x: '1', y: '2', z: '3', w: '4' });
     }));
 
@@ -270,12 +278,12 @@ describe('state', function () {
         ev.retry = deferred.promise;
         called = true;
       });
-      var promise = $state.go('AA', { a: 1 });
-      stateProvider.state('AA', { parent: A, params: [ 'a' ]});
+      var promise = $state.go('A.AA', { a: 1 });
+      stateProvider.state('A.AA', { parent: A, params: [ 'a' ]});
       deferred.resolve();
       $q.flush();
       expect(called).toBeTruthy();
-      expect($state.current.name).toEqual('AA');
+      expect($state.current.name).toEqual('A.AA');
       expect($state.params).toEqual({ a: '1' });
     }));
 
@@ -398,14 +406,14 @@ describe('state', function () {
       log += $state.current.name + ';';
       $state.transitionTo(A, {}); $q.flush();
       expect(log).toBe(
-        'A.onExit;' +
-        'D.onEnter;' +
+        'A!onExit;' +
+        'D!onEnter;' +
         'D;' +
-        'DD.onEnter;' +
-        'DD;' +
-        'DD.onExit;' +
-        'D.onExit;' +
-        'A.onEnter;');
+        'D.DD!onEnter;' +
+        'D.DD;' +
+        'D.DD!onExit;' +
+        'D!onExit;' +
+        'A!onEnter;');
     }));
 
     it('doesn\'t transition to parent state when child has no URL', inject(function ($state, $q) {
@@ -417,7 +425,7 @@ describe('state', function () {
       $state.transitionTo(DD);
       $q.flush();
 
-      var err = "Could not resolve '^.Z' from state 'DD'";
+      var err = "Could not resolve '^.Z' from state 'D.DD'";
       expect(function() { $state.transitionTo("^.Z", null, { relative: $state.$current }); }).toThrow(err);
     }));
 
@@ -460,6 +468,63 @@ describe('state', function () {
       $state.go("^.sidebar"); $q.flush();
       expect($state.$current.name).toBe('about.sidebar');
     }));
+
+    describe('absolute and object sref', function ($state, $q) {
+      var $state, $q;
+
+      beforeEach(inject(['$state', '$q', function (_$state_, _$q_) {
+        $state = _$state_;
+        $q = _$q_;
+        $state.go("home"); $q.flush();
+      }]));
+
+      it('transitions to peer', function() {
+        $state.go('A'); $q.flush();
+        expect($state.$current.name).toBe('A');
+      });
+
+      it('transitions to peer-with-child', function() {
+        $state.go('D'); $q.flush();
+        expect($state.$current.name).toBe('D');
+      });
+
+      it('transitions to own child', function() {
+        $state.go('D'); $q.flush();
+        $state.go('D.DD'); $q.flush();
+        expect($state.$current.name).toBe('D.DD');
+      });
+
+      it('transitions to child of peer', function() {
+        $state.go('D.DD'); $q.flush();
+        expect($state.$current.name).toBe('D.DD');
+      });
+
+      it('transitions to peer with `name`', function() {
+        $state.go('I'); $q.flush();
+        expect($state.$current.name).toBe('I');
+      });
+
+      it('transitions to own child with `name`', function() {
+        $state.go('I'); $q.flush();
+        $state.go('I.II'); $q.flush();
+        expect($state.$current.name).toBe('I.II');
+      });
+
+      it('transitions to child of peer with `name`', function() {
+        $state.go('I.II'); $q.flush();
+        expect($state.$current.name).toBe('I.II');
+      });
+
+      it('transitions to peer with dot-name', function() {
+        $state.go('J.JJ'); $q.flush();
+        expect($state.$current.name).toBe('J.JJ');
+      });
+
+      it('transitions to peer by reference', function() {
+        $state.go(DD); $q.flush();
+        expect($state.$current.name).toBe('D.DD');
+      });
+    });
 
     it('keeps parameters from common ancestor states', inject(function ($state, $stateParams, $q) {
       $state.transitionTo('about.person', { person: 'bob' });
@@ -621,7 +686,7 @@ describe('state', function () {
       expect($state.href("about.person", { person: "bob" })).toEqual("#/about/bob");
       expect($state.href("about.person.item", { person: "bob", id: null })).toEqual("#/about/bob/");
     }));
-    
+
     it('generates absolute url when absolute is true', inject(function ($state) {
       expect($state.href("about.sidebar", null, { absolute: true })).toEqual("http://server/#/about");
       locationProvider.html5Mode(true);
@@ -650,11 +715,15 @@ describe('state', function () {
         'B',
         'C',
         'D',
-        'DD',
+        'D.DD',
         'E',
         'H',
-        'HH',
-        'HHH',
+        'H.HH',
+        'H.HH.HHH',
+        'I',
+        'I.II',
+        'J',
+        'J.JJ',
         'RS',
         'about',
         'about.person',
@@ -786,14 +855,14 @@ describe('state', function () {
 
     it('should be inherited from parent if state doesn\'t define it', inject(function ($state) {
       initStateTo(HH);
-      expect($state.current.name).toEqual('HH');
+      expect($state.current.name).toEqual('H.HH');
       expect($state.current.data.propA).toEqual(H.data.propA);
       expect($state.current.data.propB).toEqual(H.data.propB);
     }));
 
     it('should be overridden/extended if state defines it', inject(function ($state) {
       initStateTo(HHH);
-      expect($state.current.name).toEqual('HHH');
+      expect($state.current.name).toEqual('H.HH.HHH');
       expect($state.current.data.propA).toEqual(HHH.data.propA);
       expect($state.current.data.propB).toEqual(H.data.propB);
       expect($state.current.data.propB).toEqual(HH.data.propB);
@@ -823,7 +892,7 @@ describe('state', function () {
 
     it('should include itself and parent states', inject(function ($state, $q) {
       $state.transitionTo(DD); $q.flush();
-      expect($state.$current.includes).toEqual({ '': true, D: true, DD: true });
+      expect($state.$current.includes).toEqual({ '': true, 'D': true, 'D.DD': true });
     }));
   });
 
@@ -847,7 +916,7 @@ describe('state', function () {
       });
       stateProvider.state('AA', { parent: A, data: { baz: "true" } });
 
-      $state.transitionTo('AA');
+      $state.transitionTo('A.AA');
       $q.flush();
       expect($state.current.data).toEqual({ baz: 'true', foo: 'bar' });
     }));
@@ -906,7 +975,7 @@ describe('state queue', function(){
         .state('queue-test-a.child', {})
     });
 
-  var expectedStates = ['','queue-test-a', 'queue-test-a.child', 'queue-test-b', 'queue-test-b-child'];
+  var expectedStates = ['','queue-test-a', 'queue-test-a.child', 'queue-test-b', 'queue-test-b.queue-test-b-child'];
 
   it('should work across modules', function() {
     module('ui.router.queue.test', 'ui.router.queue.test.dependency');


### PR DESCRIPTION
No more ambiguous state names. Keys in `states` data structure all represent fully-expanded dot-notation names, as do all `state.name` properties.

This thing takes a pretty optimistic viewpoint, and doesn't try and scold people for improperly mixing object-based and dot-notation based hierarchy construction.

It also mucks with user-supplied state names in config objects which might be a problem. We could probably work around this but it was much simpler to just replace the names everywhere.
