### PR TITLE
fix(registerState) canonicalize state names

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -158,14 +158,30 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
       toString: function() { return this.name; }
     });
 
-    var name = state.name;
-    if (!isString(name) || name.indexOf('@') >= 0) throw new Error("State must have a valid name");
-    if (states.hasOwnProperty(name)) throw new Error("State '" + name + "'' is already defined");
+    var name = state.name,
+        parentName,
+        lastDot = name.lastIndexOf('.');
 
     // Get parent name
-    var parentName = (name.indexOf('.') !== -1) ? name.substring(0, name.lastIndexOf('.'))
-        : (isString(state.parent)) ? state.parent
-        : '';
+    if (lastDot !== -1) {
+      parentName = name.substring(0, lastDot);
+      name = name.substring(lastDot + 1);
+    } else if (isString(state.parent)) {
+      parentName = state.parent;
+    } else if (state.parent) {
+      parentName = state.parent.name;
+    } else {
+      parentName = null;
+    }
+
+    if (parentName) {
+      name = parentName + '.' + name;
+      state.name = name;
+      state.self.name = name;
+    }
+
+    if (!isString(name) || name.indexOf('@') >= 0) throw new Error("State must have a valid name");
+    if (states.hasOwnProperty(name)) throw new Error("State '" + name + "'' is already defined");
 
     // If parent is not registered yet, add state to queue and register later
     if (parentName && !states[parentName]) {
@@ -315,7 +331,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
         toState = findState(to, options.relative);
         if (!isDefined(toState)) {
           if (options.relative) throw new Error("Could not resolve '" + to + "' from state '" + options.relative + "'");
-          throw new Error("No such state '" + to + "'");
+          throw new Error("No such state " + JSON.stringify(to));
         }
       }
       if (toState[abstractKey]) throw new Error("Cannot transition to abstract state '" + to + "'");
@@ -479,10 +495,10 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
         url = "#" + $locationProvider.hashPrefix() + url;
       }
       if (options.absolute && url) {
-        url = $location.protocol() + '://' + 
-              $location.host() + 
-              ($location.port() == 80 || $location.port() == 443 ? '' : ':' + $location.port()) + 
-              (!$locationProvider.html5Mode() && url ? '/' : '') + 
+        url = $location.protocol() + '://' +
+              $location.host() +
+              ($location.port() == 80 || $location.port() == 443 ? '' : ':' + $location.port()) +
+              (!$locationProvider.html5Mode() && url ? '/' : '') +
               url;
       }
       return url;


### PR DESCRIPTION
- State names are expanded to full dot-notation
- Absolute srefs work with `parent`-defined states

BREAKING CHANGE: code comparing against state names will need to use the fully-expanded dot-notation form. This change is most likely to affect users who use the `parent` key in state definitions to manage the state hierarchy. This includes calls to `$state.is()` and `$state.includes()`.
