### PR TITLE
add view name to $viewContentLoaded arguments

### DIFF
--- a/src/viewDirective.js
+++ b/src/viewDirective.js
@@ -1,4 +1,3 @@
-
 $ViewDirective.$inject = ['$state', '$compile', '$controller', '$injector', '$anchorScroll'];
 function $ViewDirective(   $state,   $compile,   $controller,   $injector,   $anchorScroll) {
   var $animator = $injector.has('$animator') ? $injector.get('$animator') : false;
@@ -101,7 +100,7 @@ function $ViewDirective(   $state,   $compile,   $controller,   $injector,   $an
             element.children().data('$ngControllerController', controller);
           }
           link(viewScope);
-          viewScope.$emit('$viewContentLoaded');
+          viewScope.$emit('$viewContentLoaded', name);
           if (onloadExp) viewScope.$eval(onloadExp);
 
           // TODO: This seems strange, shouldn't $anchorScroll listen for $viewContentLoaded if necessary?


### PR DESCRIPTION
$viewContentLoaded is cool event, but it will be better and useful if we can get view name within handler