### PR TITLE
fix($state): allow null to be passed as 'params' param

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -554,7 +554,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
         return false;
       }
 
-      return isDefined(params) ? angular.equals($stateParams, params) : true;
+      return isDefined(params) && params !== null ? angular.equals($stateParams, params) : true;
     };
 
     $state.includes = function includes(stateOrName, params) {

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -497,6 +497,7 @@ describe('state', function () {
     it('should return true when the current state is passed', inject(function ($state, $q) {
       $state.transitionTo(A); $q.flush();
       expect($state.is(A)).toBe(true);
+      expect($state.is(A, null)).toBe(true);
       expect($state.is('A')).toBe(true);
       expect($state.is(B)).toBe(false);
     }));


### PR DESCRIPTION
$state.is('parent.child') returns true
$state.is('parent.child', null) returns false

http://plnkr.co/edit/YnXapCQVBuutf9dL7eX3?p=preview

This may cause problems if people wish to use the changes implemented by #636 since some will opt to ignore the second parameter using 'null' rather than 'undefined'.
