### PR TITLE
feat(uiSref): add target attribute behaviour

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -87,8 +87,7 @@ function $StateRefDirective($state, $timeout) {
 
       element.bind("click", function(e) {
         var button = e.which || e.button;
-
-        if ((button === 0 || button == 1) && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
+        if ((button === 0 || button == 1) && !e.ctrlKey && !e.metaKey && !e.shiftKey && !element.attr('target')) {
           // HACK: This is to allow ng-clicks to be processed before the transition is initiated:
           $timeout(function() {
             scope.$apply(function() {

--- a/test/stateDirectivesSpec.js
+++ b/test/stateDirectivesSpec.js
@@ -149,6 +149,17 @@ describe('uiStateRef', function() {
       expect($state.current.name).toEqual('');
       expect($stateParams).toEqual({ id: "5" });
     }));
+
+    it('should not transition states when element has target specified', inject(function($state, $stateParams, $document, $q, $timeout) {
+      el.attr('target', '_blank');
+      expect($state.$current.name).toEqual('');
+
+      triggerClick(el);
+      $q.flush();
+
+      expect($state.current.name).toEqual('');
+      expect($stateParams).toEqual({ id: "5" });
+    }));
   });
 
   describe('forms', function() {


### PR DESCRIPTION
Change the behaviour of ui-sref to match angular $location service,
ignoring any click event on an anchor with a 'target' attribute set.

Closes #689
