### PR TITLE
fix(viewDirective): $injector.has() not in angular#1.0.8

### DIFF
--- a/src/viewDirective.js
+++ b/src/viewDirective.js
@@ -18,7 +18,10 @@
  */
 $ViewDirective.$inject = ['$state', '$compile', '$controller', '$injector', '$anchorScroll'];
 function $ViewDirective(   $state,   $compile,   $controller,   $injector,   $anchorScroll) {
-  var $animator = $injector.has('$animator') ? $injector.get('$animator') : false;
+  var $animator = false;
+  try {
+    $animator = $injector.get('$animator');
+  } catch(e) {}
   var viewIsUpdating = false;
 
   var directive = {


### PR DESCRIPTION
`$injector.get()` doesn't throw unless the key is not useable (like an object), or unless there is a circular dependency, so there's no issue just using it this way, so that it doesn't break 1.0.8.

[1.0.8 does not provide $injector.has()](https://github.com/angular/angular.js/blob/56817e9faa5cb9ece762bb3d6332eb9fb98f9d59/src/auto/injector.js#L597)

---

This bug breaks @mojjojo's app in 1.0.8, so a quick fix would be good for them.
