### PR TITLE
fix($state.go): param inheritance shouldn't inherit from siblings

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -37,8 +37,7 @@ function ancestors(first, second) {
   var path = [];
 
   for (var n in first.path) {
-    if (first.path[n] === "") continue;
-    if (!second.path[n]) break;
+    if (first.path[n] !== second.path[n]) break;
     path.push(first.path[n]);
   }
   return path;


### PR DESCRIPTION
Due to a bug in the ancestors() function, we were treating any states at the same depth from root as "ancestors". This means siblings were inheriting parameters from each other. Interestingly ui-sref generated the correct links, but the click handler then broke the link.

Unfortunately this is a breaking change if someone depends on the broken behavior of inheriting all the params on sibling state transitions. The fix for these folks is mostly simple: create a common parent state that contains parameters that need to be shared. Unfortunately it can introduce quite a bit of churn in the codebase.
