### PR TITLE
fix(sample): Fix 'grunt dev' and Angular script URL

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,6 +83,10 @@ module.exports = function (grunt) {
       unit: {
         browsers: [ grunt.option('browser') || 'PhantomJS' ]
       },
+      background: {
+        background: true,
+        browsers: [ grunt.option('browser') || 'PhantomJS' ]
+      },
       debug: {
         singleRun: false,
         background: false,

--- a/sample/index.html
+++ b/sample/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" type="text/css" href="styles.css">
 
     <!-- Include both angular.js and angular-ui-router.js-->
-    <script src="../lib/angular-1.1.5.js"></script>
+    <script src="../lib/angular-1.1.5/angular.js"></script>
     <script src="../build/angular-ui-router.js"></script>
 
     <!-- module.js declares the uiRouterSample module and adds items to $rootScope-->


### PR DESCRIPTION
First of all, love the project :)

`grunt dev` currently fails because the `background` target was removed from the Karma Grunt config.

Once the build is fixed, the sample app doesn't work because the script URL for AngularJS is incorrect.

Let me know if I've missed anything or if you'd like me to make any further changes.
