### PR TITLE
Fix uiSrefActive state for urlless navigation

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -65,14 +65,14 @@ function $StateRefDirective($state, $timeout) {
 
         var newHref = $state.href(ref.state, params, { relative: base });
 
+        if (uiSrefActive) {
+          uiSrefActive.$$setStateInfo(ref.state, params);
+        }
         if (!newHref) {
           nav = false;
           return false;
         }
         element[0][attr] = newHref;
-        if (uiSrefActive) {
-          uiSrefActive.$$setStateInfo(ref.state, params);
-        }
       };
 
       if (ref.paramExpr) {


### PR DESCRIPTION
fixes #738

By moving the uiSrefActive block we now set the active state on the dom nodes regardless of the url change.
