### PR TITLE
separate module, removed confusing comment

### DIFF
--- a/sample/states.js
+++ b/sample/states.js
@@ -1,5 +1,4 @@
-// Make sure to include the `ui.router` module as a dependency.
-angular.module('uiRouterSample')
+angular.module('states',[])
   .config(
     [          '$stateProvider', '$urlRouterProvider',
       function ($stateProvider,   $urlRouterProvider) {


### PR DESCRIPTION
Best practice is one module per file. Instead of copying same module names over several files, which is not DRY.

Comment is confusing - there is no inclusion of that module here!
