### PR TITLE
refactor(ui-sref): support mock-clicks/events with no data

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -87,7 +87,7 @@ function $StateRefDirective($state, $timeout) {
 
       element.bind("click", function(e) {
         var button = e.which || e.button;
-        if ((button === 0 || button == 1) && !e.ctrlKey && !e.metaKey && !e.shiftKey && !element.attr('target')) {
+        if ( !(button > 1 || e.ctrlKey || e.metaKey || e.shiftKey || element.attr('target')) ) {
           // HACK: This is to allow ng-clicks to be processed before the transition is initiated:
           $timeout(function() {
             $state.go(ref.state, params, { relative: base });

--- a/test/stateDirectivesSpec.js
+++ b/test/stateDirectivesSpec.js
@@ -118,6 +118,23 @@ describe('uiStateRef', function() {
       expect($stateParams).toEqual({ id: "5" });
     }));
 
+    it('should transition when given a click that contains no data (fake-click)', inject(function($state, $stateParams, $document, $q, $timeout) {
+      expect($state.current.name).toEqual('');
+
+      triggerClick(el, {
+        metaKey:  undefined,
+        ctrlKey:  undefined,
+        shiftKey: undefined,
+        altKey:   undefined,
+        button:   undefined 
+      });
+      $timeout.flush();
+      $q.flush();
+
+      expect($state.current.name).toEqual('contacts.item.detail');
+      expect($stateParams).toEqual({ id: "5" });
+    }));
+
     it('should not transition states when ctrl-clicked', inject(function($state, $stateParams, $document, $q) {
       expect($state.$current.name).toEqual('');
       triggerClick(el, { ctrlKey: true });


### PR DESCRIPTION
Sorry, I accidentally pushed this to origin using my old angular-ui permissions. I meant to push to my fork.  I figured it would be confusing now to delete the branch here because everyone got the notification now ... 

This problem is found in an issue at https://github.com/driftyco/ionic/issues/406 - a mock click event has to supply a `which` in the data, or ui-sref won't work.

This now inverses the logic to do nothing if `e.which` (or any event property) is the wrong value.  So event data doesn't have to be supplied now. I added a test for this, too.
