### PR TITLE
feat(uiSref): add support for transition options

### DIFF
--- a/test/stateDirectivesSpec.js
+++ b/test/stateDirectivesSpec.js
@@ -257,6 +257,33 @@ describe('uiStateRef', function() {
       expect($state.$current.name).toBe("contacts");
     }));
   });
+
+  describe('transition options', function() {
+
+    beforeEach(inject(function($rootScope, $compile, $state) {
+      el = angular.element('<a ui-sref="contacts.item.detail({ id: contact.id }, { reload: true })">Details</a>');
+      scope = $rootScope;
+      scope.contact = { id: 5 };
+      scope.$apply();
+
+      $compile(el)(scope);
+      scope.$digest();
+    }));
+
+    it('uses transition options', inject(function($q, $timeout, $state) {
+      var transitionOptions;
+
+      spyOn($state, 'go').andCallFake(function(state, params, options) {
+        transitionOptions = options;
+      });
+
+      triggerClick(el);
+      $timeout.flush();
+
+      expect(transitionOptions.reload).toEqual(true);
+    }));
+
+  });
 });
 
 describe('uiSrefActive', function() {


### PR DESCRIPTION
Allows optionally spcifying options to be passed to `$state.go`:

``` html
<a ui-sref="contacts.detail({id: contact.id}, {reload: true})">
```

will translate to

``` javascript
$state.go('contacts.detail', {id: contact.id}, {reload: true});
```

This does somewhat muddy the syntax between the `ui-sref` attribute and `$state.go`. Wondered whether a `ui-sref-options` attribute might be a better implementation?

``` html
<a ui-sref="contacts.detail({id: contact.id})" ui-sref-options="{reload: true}">
```
