### PR TITLE
Added the full version name of the release fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ui-router",
-  "version": "0.2.8",
+  "version": "0.2.8-bowratic-tedium",
   "main": "./release/angular-ui-router.js",
   "dependencies": {
     "angular": ">= 1.0.8"


### PR DESCRIPTION
Bower was downloading 0.2.8 instead of 0.2.8-bowratic-tedium because the version referenced the 0.2.8
