### PR TITLE
added support for controllerAs with function variables instead of string

### DIFF
--- a/src/viewDirective.js
+++ b/src/viewDirective.js
@@ -157,6 +157,9 @@ function $ViewDirective(   $state,   $compile,   $controller,   $injector,   $ui
           if (locals.$$controller) {
             locals.$scope = currentScope;
             var controller = $controller(locals.$$controller, locals);
+            if ($state.$current.controllerAs) {
+              currentScope[$state.$current.controllerAs] = controller;
+            }
             currentEl.children().data('$ngControllerController', controller);
           }
 

--- a/test/viewDirectiveSpec.js
+++ b/test/viewDirectiveSpec.js
@@ -77,6 +77,12 @@ describe('uiView', function () {
   },
   jState = {
     template: '<span ng-class="test">jState</span>'
+  },
+  kState = {
+    controller: function() {
+      this.someProperty = "value"
+    },
+    controllerAs: "vm",
   };
 
   beforeEach(module(function ($stateProvider) {
@@ -90,7 +96,8 @@ describe('uiView', function () {
       .state('g', gState)
       .state('g.h', hState)
       .state('i', iState)
-      .state('j', jState);
+      .state('j', jState)
+      .state('k', kState)
   }));
 
   beforeEach(inject(function ($rootScope, _$compile_) {
@@ -307,6 +314,15 @@ describe('uiView', function () {
 
       expect($uiViewScroll).toHaveBeenCalledWith(target);
     }));
+
+    it('should instantiate a controller with controllerAs', inject(function($state, $q) {
+      elem.append($compile('<div><ui-view>{{vm.someProperty}}</ui-view></div>')(scope));
+      $state.transitionTo(kState);
+      $q.flush();
+      var innerScope = scope.$$childHead
+      expect(innerScope.vm).not.toBeUndefined()
+      expect(innerScope.vm.someProperty).toBe("value")
+    }))
   });
 
 });


### PR DESCRIPTION
This is needed in addition to the `"MyController as vm"` syntax because I need to reference the controller as a function instead of a string. This is not possible currently. 

Now, by setting `controllerAs` in the state it will work. `$stateProvider.state("name", {url:"/url", controller: MyController, controllerAs:"vm"})`

This brings it in line with how angular-router works too. 

https://github.com/angular/angular.js/blob/master/src/ngRoute/directive/ngView.js#L263
