### PR TITLE
feat(uiSrefActive): nested state and DOM decendant support for ui-sref-active

### DIFF
--- a/test/stateDirectivesSpec.js
+++ b/test/stateDirectivesSpec.js
@@ -278,6 +278,8 @@ describe('uiSrefActive', function() {
       url: '/:id',
     }).state('contacts.item.detail', {
       url: '/detail/:foo'
+    }).state('contacts.item.edit', {
+      url: '/edit'
     });
   }));
 
@@ -285,51 +287,118 @@ describe('uiSrefActive', function() {
     document = $document[0];
   }));
 
-  it('should update class for sibling uiSref', inject(function($rootScope, $q, $compile, $state) {
+  it('should update class for sibling uiSref', inject(function($rootScope, $q, $compile, $state, $timeout) {
     el = angular.element('<div><a ui-sref="contacts" ui-sref-active="active">Contacts</a></div>');
     template = $compile(el)($rootScope);
     $rootScope.$digest();
+    $timeout.flush(); // emitEvent timeout hacks
 
-    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope');
     $state.transitionTo('contacts');
+    $timeout.flush(); // emitEvent timeout hacks
     $q.flush();
 
-    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope active');
 
     $state.transitionTo('contacts.item', { id: 5 });
+    $timeout.flush(); // emitEvent timeout hacks
     $q.flush();
-    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
+
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope active-nested');
   }));
 
-  it('should match state\'s parameters', inject(function($rootScope, $q, $compile, $state) {
+  it('should update class for decendant uiSrefs', inject(function($rootScope, $q, $compile, $state, $timeout) {
+    el = angular.element('<section><div ui-sref-active="active"><p ng-init="newScope=1"><a ui-sref="contacts">Contacts</a></p></div></section>');
+    template = $compile(el)($rootScope);
+    $rootScope.$digest();
+    $timeout.flush(); // emitEvent timeout hacks
+
+    expect(angular.element(template[0].querySelector('div')).attr('class')).toBe('ng-scope');
+    $state.transitionTo('contacts');
+    $timeout.flush(); // emitEvent timeout hacks
+    $q.flush();
+
+    expect(angular.element(template[0].querySelector('div')).attr('class')).toBe('ng-scope active');
+
+    $state.transitionTo('contacts.item', { id: 5 });
+    $timeout.flush(); // emitEvent timeout hacks
+    $q.flush();
+
+    expect(angular.element(template[0].querySelector('div')).attr('class')).toBe('ng-scope active-nested');
+  }));
+
+  it('should not update class for sibling elements with uiSrefs', inject(function($rootScope, $q, $compile, $state, $timeout) {
+    el = angular.element('<section><div ui-sref-active="active"></div><a ui-sref="contacts">Contacts</a></section>');
+    template = $compile(el)($rootScope);
+    $rootScope.$digest();
+    $timeout.flush(); // emitEvent timeout hacks
+
+    expect(angular.element(template[0].querySelector('div')).attr('class')).toBe('ng-scope');
+    $state.transitionTo('contacts');
+    $timeout.flush(); // emitEvent timeout hacks
+    $q.flush();
+
+    expect(angular.element(template[0].querySelector('div')).attr('class')).toBe('ng-scope');
+
+    $state.transitionTo('contacts.item', { id: 5 });
+    $timeout.flush(); // emitEvent timeout hacks
+    $q.flush();
+
+    expect(angular.element(template[0].querySelector('div')).attr('class')).toBe('ng-scope');
+  }));
+
+  it('should match state\'s parameters', inject(function($rootScope, $q, $compile, $state, $timeout) {
     el = angular.element('<div><a ui-sref="contacts.item.detail({ foo: \'bar\' })" ui-sref-active="active">Contacts</a></div>');
     template = $compile(el)($rootScope);
     $rootScope.$digest();
+    $timeout.flush(); // emitEvent timeout hacks
 
-    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope');
     $state.transitionTo('contacts.item.detail', { id: 5, foo: 'bar' });
     $q.flush();
-    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
+    $timeout.flush(); // emitEvent timeout hacks
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope active');
 
     $state.transitionTo('contacts.item.detail', { id: 5, foo: 'baz' });
     $q.flush();
-    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
+    $timeout.flush(); // emitEvent timeout hacks
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope');
   }));
 
-  it('should resolve relative state refs', inject(function($rootScope, $q, $compile, $state) {
+  it('should match child states', inject(function($rootScope, $q, $compile, $state, $timeout) {
+    el = angular.element('<div><a ui-sref="contacts.item({ id: 1 })" ui-sref-active="active">Contacts</a></div>');
+    template = $compile(el)($rootScope);
+    $rootScope.$digest();
+    $timeout.flush(); // emitEvent timeout hacks
+
+    $state.transitionTo('contacts.item.edit', { id: 1 });
+    $q.flush();
+    $timeout.flush(); // emitEvent timeout hacks
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope active-nested');
+
+    $state.transitionTo('contacts.item.edit', { id: 4 });
+    $q.flush();
+    $timeout.flush(); // emitEvent timeout hacks
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope');
+  }));
+
+  it('should resolve relative state refs', inject(function($rootScope, $q, $compile, $state, $timeout) {
     el = angular.element('<section><div ui-view></div></section>');
     template = $compile(el)($rootScope);
     $rootScope.$digest();
 
     $state.transitionTo('contacts');
+    $timeout.flush(); // emitEvent timeout hacks
     $q.flush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope');
 
     $state.transitionTo('contacts.item', { id: 6 });
+    $timeout.flush(); // emitEvent timeout hacks
     $q.flush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope active');
 
     $state.transitionTo('contacts.item', { id: 5 });
+    $timeout.flush(); // emitEvent timeout hacks
     $q.flush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope');
   }));


### PR DESCRIPTION
`uiSrefActive` now takes all decendant `uiSref`s into consideration.
`uiSrefActive` also adds a class with `-nested` postfix when a child state of the related `uiSref`s becomes active.

Implemented the consensus we previously met in #704.
