### PR TITLE
feat($state): includes() allows glob patterns for state matching.

### DIFF
--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -552,6 +552,21 @@ describe('state', function () {
       expect($state.includes('about.person', {person: 'bob'})).toBe(true);
       expect($state.includes('about.person', {person: 'steve'})).toBe(false);
     }));
+
+    it('should return true when the current state is passed with partial glob patterns', inject(function ($state, $q) {
+      $state.transitionTo('about.person.item', {person: 'bob', id: 5}); $q.flush();
+      expect($state.includes('*.person.*')).toBe(true);
+      expect($state.includes('*.person.**')).toBe(true);
+      expect($state.includes('**.item.*')).toBe(false);
+      expect($state.includes('**.item')).toBe(true);
+      expect($state.includes('**.stuff.*')).toBe(false);
+      expect($state.includes('*.*.*')).toBe(true);
+      expect($state.includes('about.*.*')).toBe(true);
+      expect($state.includes('about.**')).toBe(true);
+      expect($state.includes('*.about.*')).toBe(false);
+      expect($state.includes('about.*.*', {person: 'bob'})).toBe(true);
+      expect($state.includes('about.*.*', {person: 'shawn'})).toBe(false);
+    }));
   });
 
   describe('.current', function () {


### PR DESCRIPTION
I am currently using this to show and hide dom elements depending on state.

This is really useful if you would like to have nested states at the same position and same name but the parent is different. 

EX:
$state.contains('blah',2)

stuff.blah.re.knob => true
stuff.blah.un.good => true
carrot.blah.un.good => true
carrot.succy.un.good => false

$state.contains('stuff',1)

stuff.blah.re.knob => true
stuff.blah.un.good => true
carrot.blah.un.good => false
carrot.succy.un.good => false

If anybody has a better suggestion I'm all ears.
