### PR TITLE
Add "main" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,6 @@
     "load-grunt-tasks": "~0.2.0",
     "grunt-conventional-changelog": "~1.0.0",
     "grunt-ngdocs": "~0.1.7"
-  }
+  },
+  "main": "release/angular-ui-router"
 }


### PR DESCRIPTION
For those of us who use `npm`/`browserify` for front-end dependency management instead of bower and the like
