### PR TITLE
Use padding to keep height from header

### DIFF
--- a/sample/index.html
+++ b/sample/index.html
@@ -51,7 +51,7 @@
 
     <!-- Here is the main ui-view (unnamed) and will be populate by its immediate children's templates
          unless otherwise explicitly named views are targeted. It's also employing ng-animate. -->
-    <div ui-view class="container slide" style="margin-top: 80px;"></div>
+    <div ui-view class="container slide" style="padding-top: 80px;"></div>
 
 
     <hr>


### PR DESCRIPTION
Using margin if injected ui-view's height longer than screen.height, couldn't keep margin from header when changed state.
