### PR TITLE
fix(uiView): Do NOT autoscroll when autoscroll attr is missing

### DIFF
--- a/src/viewDirective.js
+++ b/src/viewDirective.js
@@ -100,10 +100,6 @@
  * Examples for `autoscroll`:
  *
  * <pre>
- * <!-- If autoscroll unspecified, then scroll ui-view into view
- *     (Note: this default behavior is under review and may be reversed) -->
- * <ui-view/>
- *
  * <!-- If autoscroll present with no expression,
  *      then scroll ui-view into view -->
  * <ui-view autoscroll/>
@@ -214,7 +210,7 @@ function $ViewDirective(   $state,   $injector,   $uiViewScroll) {
 
           var clone = $transclude(newScope, function(clone) {
             renderer.enter(clone, $element, function onUiViewEnter() {
-              if (!angular.isDefined(autoScrollExp) || !autoScrollExp || scope.$eval(autoScrollExp)) {
+              if (angular.isDefined(autoScrollExp) && !autoScrollExp || scope.$eval(autoScrollExp)) {
                 $uiViewScroll(clone);
               }
             });

--- a/test/viewDirectiveSpec.js
+++ b/test/viewDirectiveSpec.js
@@ -268,7 +268,7 @@ describe('uiView', function () {
   });
 
   describe('autoscroll attribute', function () {
-    it('should autoscroll when unspecified', inject(function ($state, $q, $uiViewScroll, $animate) {
+    it('should NOT autoscroll when unspecified', inject(function ($state, $q, $uiViewScroll, $animate) {
       elem.append($compile('<div><ui-view></ui-view></div>')(scope));
 
       $state.transitionTo(aState);
@@ -276,7 +276,7 @@ describe('uiView', function () {
 
       if ($animate) $animate.triggerCallbacks();
 
-      expect($uiViewScroll).toHaveBeenCalledWith(elem.find('span').parent());
+      expect($uiViewScroll).not.toHaveBeenCalled();
     }));
 
     it('should autoscroll when expression is missing', inject(function ($state, $q, $uiViewScroll, $animate) {


### PR DESCRIPTION
fix(uiView): Do NOT autoscroll when autoscroll attr is missing

Breaking Change: If you had ui-views that you wanted to autoscroll to on state change, you may now need to explicitly add `autoscroll="true"`. Fixes #807
