### PR TITLE
feat(state): add $stateResolved event

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -863,6 +863,12 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
       // keep only the outcome of the last transition.
       var transition = $state.transition = resolved.then(function () {
         var l, entering, exiting;
+        
+        evt = $rootScope.$broadcast('$stateResolved', to.self, toParams, from.self, fromParams);
+        if (evt.defaultPrevented) {
+          syncUrl();
+          return TransitionPrevented;
+        }
 
         if ($state.transition !== transition) return TransitionSuperseded;
 


### PR DESCRIPTION
$stateResolved fires after state resolved with possibility to prevent event.
Such functionality is useful for login system, when we need get current user first,
and then, based on response, redirect to login page or continue.
