### PR TITLE
feat(UrlMatcher): Add support for case insensitive url matching

### DIFF
--- a/src/urlMatcherFactory.js
+++ b/src/urlMatcherFactory.js
@@ -39,6 +39,7 @@
  * * `'/files/*path'` - ditto.
  *
  * @param {string} pattern  the pattern to compile into a matcher.
+ * @param {bool} caseInsensitiveMatch true if url matching should be case insensitive, otherwise false, the default value (for backward compatibility) is false.
  *
  * @property {string} prefix  A static prefix of this pattern. The matcher guarantees that any
  *   URL matching this matcher (i.e. any string for which {@link ui.router.util.type:UrlMatcher#methods_exec exec()} returns
@@ -55,7 +56,7 @@
  *
  * @returns {Object}  New UrlMatcher object
  */
-function UrlMatcher(pattern) {
+function UrlMatcher(pattern, caseInsensitiveMatch) {
 
   // Find all placeholders and create a compiled pattern, using either classic or curly syntax:
   //   '*' name
@@ -119,7 +120,12 @@ function UrlMatcher(pattern) {
 
   compiled += quoteRegExp(segment) + '$';
   segments.push(segment);
-  this.regexp = new RegExp(compiled);
+  if(caseInsensitiveMatch){
+    this.regexp = new RegExp(compiled, 'i');
+  }else{
+    this.regexp = new RegExp(compiled);	
+  }
+  
   this.prefix = segments[0];
 }
 
@@ -263,6 +269,22 @@ UrlMatcher.prototype.format = function (values) {
  */
 function $UrlMatcherFactory() {
 
+  var useCaseInsensitiveMatch = false;
+
+  /**
+   * @ngdoc function
+   * @name ui.router.util.$urlMatcherFactory#caseInsensitiveMatch
+   * @methodOf ui.router.util.$urlMatcherFactory
+   *
+   * @description
+   * Define if url matching should be case sensistive, the default behavior, or not.
+   *   
+   * @param {bool} value false to match URL in a case sensitive manner; otherwise true;
+   */
+  this.caseInsensitiveMatch = function(value){
+    useCaseInsensitiveMatch = value;
+  };
+
   /**
    * @ngdoc function
    * @name ui.router.util.$urlMatcherFactory#compile
@@ -275,7 +297,7 @@ function $UrlMatcherFactory() {
    * @returns {ui.router.util.type:UrlMatcher}  The UrlMatcher.
    */
   this.compile = function (pattern) {
-    return new UrlMatcher(pattern);
+    return new UrlMatcher(pattern, useCaseInsensitiveMatch);
   };
 
   /**

--- a/test/urlMatcherFactorySpec.js
+++ b/test/urlMatcherFactorySpec.js
@@ -3,6 +3,10 @@ describe("UrlMatcher", function () {
     expect(new UrlMatcher('/hello/world').exec('/hello/world')).toEqual({});
   });
 
+  it("matches static case insensitive URLs", function () {
+    expect(new UrlMatcher('/hello/world', true).exec('/heLLo/World')).toEqual({});
+  });
+
   it("matches against the entire path", function () {
     var matcher = new UrlMatcher('/hello/world');
     expect(matcher.exec('/hello/world/')).toBeNull();
@@ -138,5 +142,14 @@ describe("urlMatcherFactory", function () {
 
   it("recognizes matchers", function () {
     expect($umf.isMatcher(new UrlMatcher('/'))).toBe(true);
+  });
+
+  it("should handle case sensistive URL by default", function () {
+    expect($umf.compile('/hello/world').exec('/heLLo/WORLD')).toBeNull();
+  });
+
+  it("should handle case insensistive URL", function () {
+  	$umf.caseInsensitiveMatch(true);
+    expect($umf.compile('/hello/world').exec('/heLLo/WORLD')).toEqual({});
   });
 });


### PR DESCRIPTION
Add support for case insensitive url matching, by default url match is case sensitive, for backward compatibility. Case sensitive match can be turned on/off globally via $urlMatcherFactoryProvider caseInsensitiveMatch( true/false ) method.
