### PR TITLE
fix(uiSref): cancel transition if preventDefault() has been called

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -128,10 +128,14 @@ function $StateRefDirective($state, $timeout) {
         var button = e.which || e.button;
         if ( !(button > 1 || e.ctrlKey || e.metaKey || e.shiftKey || element.attr('target')) ) {
           // HACK: This is to allow ng-clicks to be processed before the transition is initiated:
-          $timeout(function() {
+          var transition = $timeout(function() {
             $state.go(ref.state, params, options);
           });
           e.preventDefault();
+
+          e.preventDefault = function() {
+            $timeout.cancel(transition);
+          };
         }
       });
     }


### PR DESCRIPTION
When using `ui-sref` directive, you can't cancel state transition by calling `preventDefault()` in a click handler.

Note that this solution does not solve the problem completely (`e.defaultPrevented` will be always true when transition is delayed).
