### PR TITLE
check defaultPrevented before sync url on failure

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -946,8 +946,11 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
          * @param {Object} fromParams The params supplied to the `fromState`.
          * @param {Error} error The resolve error object.
          */
-        $rootScope.$broadcast('$stateChangeError', to.self, toParams, from.self, fromParams, error);
-        syncUrl();
+        evt = $rootScope.$broadcast('$stateChangeError', to.self, toParams, from.self, fromParams, error);
+
+        if (!evt.defaultPrevented) {
+            syncUrl();
+        }
 
         return $q.reject(error);
       });

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -777,6 +777,21 @@ describe('state', function () {
       expect($state.current.name).toBe("about");
     }));
 
+    it('should not revert to last known working url on state change failure', inject(function ($state, $rootScope, $location, $q) {
+      $state.transitionTo("about");
+      $q.flush();
+
+      $rootScope.$on("$stateChangeError", function(event){
+          event.defaultPrevented = true;
+      });
+
+      $location.path("/resolve-fail");
+      $rootScope.$broadcast("$locationChangeSuccess");
+      $rootScope.$apply();
+
+      expect($location.path()).toBe("/resolve-fail");
+    }));
+
     it('should replace browser history when "replace" enabled', inject(function ($state, $rootScope, $location, $q) {
       var originalReplaceFn = $location.replace, replaceWasCalled = false;
 


### PR DESCRIPTION
I need **the user to be informed** there is an error on the target state. The first problem is the syncUrl that cannot be prevented on error, so the user has no informations of what happen and sometimes we (developers) want to give him some clues (eg. Url)

Actually I'm not sure if it is the good way to solve this problem : 

I've a promise in the resolve corresponding to an url parameter. **If the parameter is bad** I want forward the user to an other state (eg. error404)  without changing the url ... like a regular 404 error.

Then this is the kind of thing I try to do in the most simple way (In my mind ... ok;) ) : 

``` javascript
angular.module('myModule')
.config(["$stateProvider", function($stateProvider, $urlRouterProvider) {
    $stateProvider.state("page", {
        "url": "/page/{code}",
        "resolve": {
            "page": ["$q", "$stateParams", function($q, $stateParams) {
                var deferred = $q.defer();
                if (-1 !== ["a", "b"].indexOf($stateParams.code)) {
                    deferred.resolve({"code": $stateParams.code, "content": "A silly page"});
                } else {
                    deferred.reject({"message": "not found"});
                }
                return deferred.promise;
            }]
        }
    })
    .state("error", {});
}])
.run(["$rootScope", "$state", function($rootScope, $state) {
    $rootScope.$on('$stateChangeError', function(event) {
        event.defaultPrevented = false;
        $state.transitionTo("error");
    });
}]);
```
