### PR TITLE
$state.href inherit parameter fix

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -1096,7 +1096,8 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
       var state = findState(stateOrName, options.relative);
       if (!isDefined(state)) return null;
 
-      params = inheritParams($stateParams, params || {}, $state.$current, state);
+      if (options.inherit) params = inheritParams($stateParams, params || {}, $state.$current, state);
+      
       var nav = (state && options.lossy) ? state.navigable : state;
       var url = (nav && nav.url) ? nav.url.format(normalize(state.params, params || {})) : null;
       if (!$locationProvider.html5Mode() && url) {

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -643,6 +643,13 @@ describe('state', function () {
       expect($state.href("about.person", { person: "bob" })).toEqual("#/about/bob");
       expect($state.href("about.person.item", { person: "bob", id: null })).toEqual("#/about/bob/");
     }));
+
+    it('inherit url parameters from current url', inject(function ($state) {
+      initStateTo($state.get('root'), {param1: 1});
+      expect($state.href("root", {}, {})).toEqual("#/root");
+      expect($state.href("root", {}, {inherit:false})).toEqual("#/root");
+      expect($state.href("root", {}, {inherit:true})).toEqual("#/root?param1=1");
+    }));
     
     it('generates absolute url when absolute is true', inject(function ($state) {
       expect($state.href("about.sidebar", null, { absolute: true })).toEqual("http://server/#/about");


### PR DESCRIPTION
fix($state.href): didn't complied to inherit parameter

$state.href didnt' complied to inherit parameter. Parameters aren't inherited anymore when inherit: false
