### PR TITLE
fix(findState) for undefined stateName

### DIFF
--- a/release/angular-ui-router.js
+++ b/release/angular-ui-router.js
@@ -1326,6 +1326,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory,           $
   }
 
   function findState(stateOrName, base) {
+    if(!stateOrName)return false // omit requests for undefined states
     var isStr = isString(stateOrName),
         name  = isStr ? stateOrName : stateOrName.name,
         path  = isRelative(name);


### PR DESCRIPTION
In combination with angular translate, sometimes 'stateName' is undefined.
