### PR TITLE
docs(readme): fix broken link to states

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 AngularUI Router is a routing framework for [AngularJS](http://angularjs.org), which allows you to organize the
 parts of your interface into a [*state machine*](https://en.wikipedia.org/wiki/Finite-state_machine). Unlike the
 [`$route` service](http://docs.angularjs.org/api/ngRoute.$route) in Angular core, which is organized around URL
-routes, UI-Router is organized around [*states*](https://github.com/angular-ui/ui-router/blob/master/sample/states.js#L28-L269),
+routes, UI-Router is organized around [*states*](https://github.com/angular-ui/ui-router/wiki),
 which may optionally have routes, as well as other behavior, attached.
 
 States are bound to *named*, *nested* and *parallel views*, allowing you to powerfully manage your application's interface.


### PR DESCRIPTION
Linking to the wiki now that we've replaced the sample states.js file with a sample application (which could be intimidating to someone who just wants to understand what a state actually is). 
