### PR TITLE
feat($state): Make variable 'states' public in $stateProvider

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -23,6 +23,7 @@ $StateProvider.$inject = ['$urlRouterProvider', '$urlMatcherFactoryProvider'];
 function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
 
   var root, states = {}, $state, queue = {}, abstractKey = 'abstract';
+  this.$states=states;
 
   // Builds state properties from definition passed to registerState()
   var stateBuilder = {


### PR DESCRIPTION
Allow access to variable `states` in `$stateProvider` for extending $state using angular's [decorator](http://docs.angularjs.org/api/auto/object/$provide#decorator)
This need to extend `resolve` property of state.