### PR TITLE
Handle regexp patterns with subgroups.

### DIFF
--- a/test/urlMatcherFactorySpec.js
+++ b/test/urlMatcherFactorySpec.js
@@ -106,25 +106,20 @@ describe("UrlMatcher", function () {
       expect(new UrlMatcher('/users/:id').exec('/users/100%25', {})).toEqual({ id: '100%25'});
     });
 
-    it('should throw on unbalanced capture list', function () {
-      var shouldThrow = {
-        "/url/{matchedParam:([a-z]+)}/child/{childParam}": '/url/someword/child/childParam',
-        "/url/{matchedParam:([a-z]+)}/child/{childParam}?foo": '/url/someword/child/childParam'
-      };
-
-      angular.forEach(shouldThrow, function(url, route) {
-        expect(function() { new UrlMatcher(route).exec(url, {}); }).toThrow(
-          "Unbalanced capture group in route '" + route + "'"
-        );
-      });
-
+    it('should capture regexp subgroups', function () {
       var shouldPass = {
-        "/url/{matchedParam:[a-z]+}/child/{childParam}": '/url/someword/child/childParam',
-        "/url/{matchedParam:[a-z]+}/child/{childParam}?foo": '/url/someword/child/childParam'
+        "/url/{matchedParam:([a-z]+)}/child/{childParam}": {
+          route: '/url/someword/child/childParam',
+          match: {matchedParam: 'someword', childParam: 'childParam'}
+        },
+        "/url/{matchedParam:(([a-z])[a-z]*)}/child/{childParam}?foo": {
+          route: '/url/someword/child/childParam',
+          match: {matchedParam: 'someword', childParam: 'childParam', foo: undefined}
+        }
       };
 
-      angular.forEach(shouldPass, function(url, route) {
-        expect(function() { new UrlMatcher(route).exec(url, {}); }).not.toThrow();
+      angular.forEach(shouldPass, function(v, url) {
+        expect(new UrlMatcher(url).exec(v.route, {})).toEqual(v.match);
       });
     });
   });


### PR DESCRIPTION
Currently, in UrlMatcher, subgrouping in regexp patterns is not supported. This seems to be an expected behavior; there is a check+throw for it, and even a test (although I find the thrown error "Unbalanced capture group" misleading).

This request changes this behavior. Subgroups are allowed in regexps, and such regexps work just like subgroup-free ones.

So:
- Pattern: `/url/{matchedParam:(([a-z])[a-z]*)}/child/{childParam}`
- with URL: `/url/someword/child/childParam`
- yields: `{matchedParam: 'someword', childParam: 'childParam'}`

I don't see a reason for this not to be the case, as subgroups are a core element of regular expressions; if you do, I would be grateful if you explained it.
