### PR TITLE
Use ng-animate with ui-sref-active

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -221,7 +221,7 @@ $StateRefActiveDirective.$inject = ['$state', '$stateParams', '$interpolate'];
 function $StateRefActiveDirective($state, $stateParams, $interpolate) {
   return  {
     restrict: "A",
-    controller: ['$scope', '$element', '$attrs', function ($scope, $element, $attrs) {
+    controller: ['$scope', '$element', '$attrs', '$animate', function($scope, $element, $attrs, $animate) {
       var state, params, activeClass;
 
       // There probably isn't much point in $observing this
@@ -241,9 +241,9 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate) {
       // Update route state
       function update() {
         if (isMatch()) {
-          $element.addClass(activeClass);
+          $animate.addClass($element, activeClass);
         } else {
-          $element.removeClass(activeClass);
+          $animate.removeClass($element, activeClass);
         }
       }
 


### PR DESCRIPTION
I wanted to use `ng-animate` with ui-sref-active so I made a relatively simple change to the directive.

After looking at ViewDirective's use of the `$animate` service, I see that some rather non-trivial things were done for backwards compatibility, etc. I don't feel qualified to copy over that logic, or refactor that logic into a service, so you probably won't be merging my code as-is.

Still, it's here as a feature request / proof-of-concept.

I was very satisfied with the results in my project!
