### PR TITLE
fix($state): change default value of `inherit` option to `true`

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -1091,7 +1091,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
      * - **`lossy`** - {boolean=true} -  If true, and if there is no url associated with the state provided in the
      *    first parameter, then the constructed href url will be built from the first navigable ancestor (aka
      *    ancestor with a valid url).
-     * - **`inherit`** - {boolean=false}, If `true` will inherit url parameters from current url.
+     * - **`inherit`** - {boolean=true}, If `true` will inherit url parameters from current url.
      * - **`relative`** - {object=$state.$current}, When transitioning with relative path (e.g '^'), 
      *    defines which state to be relative from.
      * - **`absolute`** - {boolean=false},  If true will generate an absolute url, e.g. "http://www.example.com/fullurl".
@@ -1101,7 +1101,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
     $state.href = function href(stateOrName, params, options) {
       options = extend({
         lossy:    true,
-        inherit:  false,
+        inherit:  true,
         absolute: false,
         relative: $state.$current
       }, options || {});

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -649,7 +649,7 @@ describe('state', function () {
 
     it('inherit url parameters from current url', inject(function ($state) {
       initStateTo($state.get('root'), {param1: 1});
-      expect($state.href("root", {}, {})).toEqual("#/root");
+      expect($state.href("root", {}, {})).toEqual("#/root?param1=1");
       expect($state.href("root", {}, {inherit:false})).toEqual("#/root");
       expect($state.href("root", {}, {inherit:true})).toEqual("#/root?param1=1");
     }));


### PR DESCRIPTION
Since #970, `href()` method takes into account the `inherit` option. It's a good thing but the default behavior of `href()` is now different because of the `false` default value of `inherit` options. It will result a breaking change in the next release 0.3.0.

Here are 2 plunkers to demonstrate that:
- [Plunker](http://plnkr.co/edit/EX7p2SHgQb5guolM6621?p=preview) with ui-router 0.2.10: params are inherited 
- [Plunker](http://plnkr.co/edit/TzCeSUCKmAUfr4UxTW6Z?p=preview) with ui-router master: params are no longer inherited

To avoid that, I change the default value to `true`. The default behavior is exactly the same as before the #970.

Moreover, I think a `true` default value is more convenient for this "high level oriented" method, like `go()` which has `true` default value too (as opposition to `transitionTo`, a lower level method).

I found the problem when a user of my repository ([angular-breadcrumb](https://github.com/ncuillery/angular-breadcrumb)) has reported an [issue](https://github.com/ncuillery/angular-breadcrumb/pull/13) (thank to you @fwitzke).
