### PR TITLE
Add support for state parameters to the 'isState' and 'includedByState' filters

### DIFF
--- a/src/stateFilters.js
+++ b/src/stateFilters.js
@@ -6,11 +6,13 @@
  *
  * @description
  * Translates to {@link ui.router.state.$state#methods_is $state.is("stateName")}.
+ *
+ * @param {Object} The params object
  */
 $IsStateFilter.$inject = ['$state'];
 function $IsStateFilter($state) {
-  return function(state) {
-    return $state.is(state);
+  return function(state, params) {
+    return $state.is(state, params);
   };
 }
 
@@ -22,11 +24,13 @@ function $IsStateFilter($state) {
  *
  * @description
  * Translates to {@link ui.router.state.$state#methods_includes $state.includes('fullOrPartialStateName')}.
+ *
+ * @param {Object} The params object
  */
 $IncludedByStateFilter.$inject = ['$state'];
 function $IncludedByStateFilter($state) {
-  return function(state) {
-    return $state.includes(state);
+  return function(state, params) {
+    return $state.includes(state, params);
   };
 }
 


### PR DESCRIPTION
Without the support for the parameters argument, there is still a need to expose $state on the scope if I want to compare states on their parameters as well.
