### PR TITLE
fix(ui-sref): Allow sref state options to take a scope object

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -100,7 +100,7 @@ function $StateRefDirective($state, $timeout) {
       });
 
       var update = function(newVal) {
-        if (newVal) params = newVal;
+        if (newVal) params = angular.copy(newVal);
         if (!nav) return;
 
         newHref = $state.href(ref.state, params, options);
@@ -120,7 +120,7 @@ function $StateRefDirective($state, $timeout) {
         scope.$watch(ref.paramExpr, function(newVal, oldVal) {
           if (newVal !== params) update(newVal);
         }, true);
-        params = scope.$eval(ref.paramExpr);
+        params = angular.copy(scope.$eval(ref.paramExpr));
       }
       update();
 

--- a/test/stateDirectivesSpec.js
+++ b/test/stateDirectivesSpec.js
@@ -243,6 +243,20 @@ describe('uiStateRef', function() {
       $rootScope.$digest();
       expect(el.attr('href')).toBe('#/contacts/3');
     }));
+
+    it('should take an object as a parameter and update properly on digest churns', inject(function($rootScope, $q, $compile, $state) {
+
+      el = angular.element('<div><a ui-sref="contacts.item.detail(urlParams)">Contacts</a></div>');
+      template = $compile(el)($rootScope);
+
+      $rootScope.urlParams = { id:1 };
+      $rootScope.$digest();
+      expect(angular.element(template[0].querySelector('a')).attr('href')).toBe('#/contacts/1');
+
+      $rootScope.urlParams.id = 2;
+      $rootScope.$digest();
+      expect(angular.element(template[0].querySelector('a')).attr('href')).toBe('#/contacts/2');
+    }));
   });
 
   describe('links in html5 mode', function() {


### PR DESCRIPTION
The tests pretty well outline the problem. Look at them if you want to see what is accomplished.

Basically when you try to use an object on a scope as your parameters for ui-sref. On a digest churn no updates occur. This fixes that problem.

```
$rootscope.scopeVar = {a:'1',b:'asd'}
ui-sref="something.something(scopeVar)"
```
