### PR TITLE
feat(templateUrl): Allow templateUrl to accept array

### DIFF
--- a/src/templateFactory.js
+++ b/src/templateFactory.js
@@ -81,6 +81,7 @@ function $TemplateFactory(  $http,   $templateCache,   $injector) {
    */
   this.fromUrl = function (url, params) {
     if (isFunction(url)) url = url(params);
+    if (isArray(url)) url = $injector.invoke(url, null, { params: params });
     if (url == null) return null;
     else return $http
         .get(url, { cache: $templateCache })


### PR DESCRIPTION
Change templateUrl so that an array can be used
as an argument instead of just function or string.
Otherwise, ngMin does not properly minify the
templateUrl function.

Additionally, dependencies are not supported in the current setup.

For example, this currently returns a url-ified array as a string and in turn raises an error.

``` js
.state('someState', {
  templateUrl: ['dependency', function (dependency) {
    if (dependency.something) {
      // return a url;
    } else {
      // return a different url;
    }
  }];
});
```
