### PR TITLE
Change 'this' with $state in $state.go

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -716,7 +716,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
      *
      */
     $state.go = function go(to, params, options) {
-      return this.transitionTo(to, params, extend({ inherit: true, relative: $state.$current }, options));
+      return $state.transitionTo(to, params, extend({ inherit: true, relative: $state.$current }, options));
     };
 
     /**


### PR DESCRIPTION
It would make `$state.go` more consistent with the style used anywhere else in the code.
