### PR TITLE
Restore comment in .run function call

### DIFF
--- a/sample/app/app.js
+++ b/sample/app/app.js
@@ -13,8 +13,8 @@ angular.module('uiRouterSample', [
 
     // It's very handy to add references to $state and $stateParams to the $rootScope
     // so that you can access them from any scope within your applications.For example,
-    // <li ui-sref-active="active }"> will set the <li> // to active whenever
-    // 'contacts.list' or one of its decendents is active.
+    // <li ng-class="{ active: $state.includes('contacts.list') }"> will set the <li>
+    // to active whenever 'contacts.list' or one of its decendents is active.
     $rootScope.$state = $state;
     $rootScope.$stateParams = $stateParams;
     }


### PR DESCRIPTION
In a previous version there was a example of how to use the $state inside a ng-class.
