### PR TITLE
support setting url #fragments in state params

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -815,7 +815,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       }
 
       // Filter parameters before we pass them to event handlers etc.
-      toParams = filterByKeys(objectKeys(to.params), toParams || {});
+      toParams = filterByKeys(objectKeys(to.params).concat('#'), toParams || {});
 
       // Broadcast start event and cancel the transition if requested
       if (options.notify) {
@@ -1116,7 +1116,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       if (!nav || !nav.url) {
         return null;
       }
-      return $urlRouter.href(nav.url, filterByKeys(objectKeys(state.params), params || {}), {
+      return $urlRouter.href(nav.url, filterByKeys(objectKeys(state.params).concat('#'), params || {}), {
         absolute: options.absolute
       });
     };

--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -1,9 +1,9 @@
 function parseStateRef(ref, current) {
   var preparsed = ref.match(/^\s*({[^}]*})\s*$/), parsed;
   if (preparsed) ref = current + '(' + preparsed[1] + ')';
-  parsed = ref.replace(/\n/g, " ").match(/^([^(]+?)\s*(\((.*)\))?$/);
-  if (!parsed || parsed.length !== 4) throw new Error("Invalid state ref '" + ref + "'");
-  return { state: parsed[1], paramExpr: parsed[3] || null };
+  parsed = ref.replace(/\n/g, " ").match(/^([^(]+?)\s*(\((.*)\))?(#(.*?))?$/);
+  if (!parsed || parsed.length < 4) throw new Error("Invalid state ref '" + ref + "'");
+  return { state: parsed[1], paramExpr: parsed[3] || null, '#': parsed[5] };
 }
 
 function stateContext(el) {
@@ -102,8 +102,16 @@ function $StateRefDirective($state, $timeout) {
         if (newVal) params = newVal;
         if (!nav) return;
 
-        var newHref = $state.href(ref.state, params, options);
+        if (ref['#']) {
+          if (angular.isObject(params)) {
+            params['#'] = ref['#'];
+          } else {
+            params = { '#': ref['#'] };
+          }
+        }
 
+        var newHref = $state.href(ref.state, params, options);
+          
         var activeDirective = uiSrefActive[1] || uiSrefActive[0];
         if (activeDirective) {
           activeDirective.$$setStateInfo(ref.state, params);

--- a/src/urlRouter.js
+++ b/src/urlRouter.js
@@ -350,6 +350,7 @@ function $UrlRouterProvider(   $locationProvider,   $urlMatcherFactory) {
       push: function(urlMatcher, params, options) {
         $location.url(urlMatcher.format(params || {}));
         if (options && options.replace) $location.replace();
+        if (params && params['#']) $location.hash(params['#']);
       },
 
       /**
@@ -386,6 +387,9 @@ function $UrlRouterProvider(   $locationProvider,   $urlMatcherFactory) {
 
         if (!isHtml5 && url) {
           url = "#" + $locationProvider.hashPrefix() + url;
+        }
+        else if (isHtml5 && params['#']) {
+	      url += '#' + params['#'];
         }
         url = appendBasePath(url, isHtml5, options.absolute);
 


### PR DESCRIPTION
As per @sadlerw's request in #701

NB: obviously HTML5 mode needs to be enabled for this to have any effect
Supports both formats:
- `ui-sref="mystate(myparams)#{{ myhashexpression }}"`
- `ui-sref="mystate({myparam1: myvalue1, myparam2: myvalue2, '#': myhashexpression})"`
