### PR TITLE
fix(docs): Removed an incorrect semi-colon

### DIFF
--- a/src/urlRouter.js
+++ b/src/urlRouter.js
@@ -315,7 +315,7 @@ function $UrlRouterProvider(   $locationProvider,   $urlMatcherFactory) {
        *
        * @example
        * <pre>
-       * angular.module('app', ['ui.router']);
+       * angular.module('app', ['ui.router'])
        *   .run(function($rootScope, $urlRouter) {
        *     $rootScope.$on('$locationChangeSuccess', function(evt) {
        *       // Halt state change from even starting


### PR DESCRIPTION
Function ui.router.router.$urlRouter#sync had an example with an incorrect semi-colon. Removed to avoid confusion.
