### PR TITLE
fixes #1079

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -1189,7 +1189,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
   }
 
   function shouldTriggerReload(to, from, locals, options) {
-    if (to === from && ((locals === from.locals && !options.reload) || (to.self.reloadOnSearch === false))) {
+    if (to === from && ((locals === from.locals) || (to.self.reloadOnSearch === false)) && !options.reload) {
       return true;
     }
   }


### PR DESCRIPTION
state will now be reloaded if `state.reloadOnSearch = false` when doing `state.go('stateName', {reload: true})`
