### PR TITLE
feat($state): "independent" (child) state

### DIFF
--- a/sample/app/app.js
+++ b/sample/app/app.js
@@ -94,16 +94,16 @@ angular.module('uiRouterSample', [
 
         .state('me', {
           url: '/me',
-          template: "<h1>Me, <a ui-sref=\"giserman\">Giserman</a></h1>"
+          template: "<h1>Me, <a ui-sref=\"myself\">myself</a></h1>"
         })
 
-        .state('giserman', {
+        .state('myself', {
           parent: 'me',
           independent: true,
-          url: '/giserman',
+          url: '/myself',
           views: {
-            'giserman@': {
-              template: "<h1>Giserman, <a ui-sref=\"^\">me</a></h1>"
+            'myself@': {
+              template: "<h1>Myself, <a ui-sref=\"^\">me</a></h1>"
             }
           }
         })

--- a/sample/index.html
+++ b/sample/index.html
@@ -12,7 +12,7 @@
     <!-- Include both angular.js and angular-ui-router.js-->
     <script src="../lib/angular-1.2.14/angular.js"></script>
     <script src="../lib/angular-1.2.14/angular-animate.js"></script>
-    <script src="../build/angular-ui-router.js"></script>
+    <script src="../release/angular-ui-router.js"></script>
 
     <!-- app.js declares the uiRouterSample module and adds items to $rootScope, and defines
          the "home" and "about" states
@@ -62,7 +62,7 @@
     <!-- Here is the main ui-view (unnamed) and will be populated by its immediate children's templates
          unless otherwise explicitly named views are targeted. It's also employing ng-animate. -->
     <div ui-view class="container slide" style="padding-top: 80px;"></div>
-    <div ui-view="giserman" class="container slide"></div>
+    <div ui-view="myself" class="container slide"></div>
 
 
     <hr>

--- a/src/state.js
+++ b/src/state.js
@@ -27,6 +27,11 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
   // Builds state properties from definition passed to registerState()
   var stateBuilder = {
 
+    // Independent child state inherits everything from it's parent, as usual, but won't render nor keep inherited views.
+    independent: function(state) {
+      if (isDefined(state.parent)) return isDefined(state.independent) ? state.independent : false;
+    },
+
     // Derive parent state from a hierarchical name only if 'parent' is not explicitly defined.
     // state.children = [];
     // if (parent) parent.children.push(state);
@@ -795,7 +800,8 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       // Starting from the root of the path, keep all levels that haven't changed
       var keep = 0, state = toPath[keep], locals = root.locals, toLocals = [];
 
-      if (!options.reload) {
+      // Force state to reload if coming from an independent child
+      if (!options.reload && !from.independent) {
         while (state && state === fromPath[keep] && equalForKeys(toParams, fromParams, state.ownParams)) {
           locals = toLocals[keep] = state.locals;
           keep++;


### PR DESCRIPTION
If state parent's defined, "independent" property can be set and won't render nor keep it's parent's view(s)/templates (as long it's own ui-view(s) is outside of it's parent's, of course). But inherits everything else, as usual.
