### PR TITLE
Check that state variable is defined in isMatch()

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -251,7 +251,7 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate) {
         if (typeof $attrs.uiSrefActiveEq !== 'undefined') {
           return $state.$current.self === state && matchesParams();
         } else {
-          return $state.includes(state.name) && matchesParams();
+          return state && $state.includes(state.name) && matchesParams();
         }
       }
 


### PR DESCRIPTION
Prevents an error from being thrown if `ui-sref-active` is inadvertently used without a corresponding `ui-sref` directive. See #1314.
