### PR TITLE
feat($state): .reload() returns state transition promise

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -644,9 +644,12 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
      *   reload: true, inherit: false, notify: false 
      * });
      * </pre>
+     *
+     * @returns {promise} A promise representing the state of the new transition. See
+     * {@link ui.router.state.$state#methods_go $state.go}.
      */
     $state.reload = function reload() {
-      $state.transitionTo($state.current, $stateParams, { reload: true, inherit: false, notify: false });
+      return $state.transitionTo($state.current, $stateParams, { reload: true, inherit: false, notify: false });
     };
 
     /**

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -487,6 +487,16 @@ describe('state', function () {
   });
 
   describe('.reload()', function () {
+   it('returns a promise for the state transition', inject(function ($state, $q) {
+      var trans = $state.transitionTo(A, {});
+      $q.flush();
+      expect(resolvedValue(trans)).toBe(A);
+
+      trans = $state.reload();
+      $q.flush();
+      expect(resolvedValue(trans)).toBe(A);
+    }));
+
     it('should reload the current state with the current parameters', inject(function ($state, $q, $timeout) {
       $state.transitionTo('resolveTimeout', { foo: "bar" });
       $q.flush();


### PR DESCRIPTION
You could want to perform an action after a state is reloaded
Since .reload() is a shortcut for .transitionTo(), it makes sense to pass on the promise
