### PR TITLE
feat($templateFactory): request templateURL as text/html

### DIFF
--- a/src/templateFactory.js
+++ b/src/templateFactory.js
@@ -83,7 +83,7 @@ function $TemplateFactory(  $http,   $templateCache,   $injector) {
     if (isFunction(url)) url = url(params);
     if (url == null) return null;
     else return $http
-        .get(url, { cache: $templateCache })
+        .get(url, { cache: $templateCache, headers: { Accept: 'text/html' }})
         .then(function(response) { return response.data; });
   };
 

--- a/test/templateFactorySpec.js
+++ b/test/templateFactorySpec.js
@@ -1,8 +1,16 @@
 describe('templateFactory', function () {
-  
+
   beforeEach(module('ui.router.util'));
 
   it('exists', inject(function ($templateFactory) {
     expect($templateFactory).toBeDefined();
+  }));
+
+  it('should request templates as text/html', inject(function($templateFactory, $httpBackend) {
+    $httpBackend.expectGET('views/view.html', function(headers) {
+      return headers.Accept === 'text/html';
+    }).respond(200);
+    $templateFactory.fromUrl('views/view.html');
+    $httpBackend.flush();
   }));
 });


### PR DESCRIPTION
Added `Accept: text/html` to headers of `$http.get` invocation:

![image](https://cloud.githubusercontent.com/assets/2935356/4174128/75cddbe0-357b-11e4-9ef4-1d222813e52a.png)

Added additional unit test to `templateFactorySpec.js`:

![image](https://cloud.githubusercontent.com/assets/2935356/4174131/93906f8a-357b-11e4-9119-0e49876a7fdd.png)

This closes issue #1287
