### PR TITLE
It would be nice to use abstract states in ui-sref in some cases

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -775,7 +775,14 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
 
       var from = $state.$current, fromParams = $state.params, fromPath = from.path;
       var evt, toState = findState(to, options.relative);
-
+      
+      // handle default child sequence
+      while(toState[abstractKey] && (typeof to == 'string') && toState.defaultChild)
+      {
+    	  to = to+'.'+toState.defaultChild;
+    	  toState = findState(to, options.relative);
+      }
+      
       if (!isDefined(toState)) {
         var redirect = { to: to, toParams: toParams, options: options };
         var redirectResult = handleRedirect(redirect, from.self, fromParams, options);

--- a/src/state.js
+++ b/src/state.js
@@ -779,8 +779,8 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       // handle default child sequence
       while(toState[abstractKey] && (typeof to == 'string') && toState.defaultChild)
       {
-    	  to = to+'.'+toState.defaultChild;
-    	  toState = findState(to, options.relative);
+        to = to + '.' + toState.defaultChild;
+        toState = findState(to, options.relative);
       }
       
       if (!isDefined(toState)) {

--- a/src/state.js
+++ b/src/state.js
@@ -120,7 +120,12 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       includes[state.name] = true;
       return includes;
     },
-
+    
+    // Allows to use abstract state in ui-sref
+    defaultChild: function(state) {
+      return state.defaultChild;
+    },
+    
     $delegates: {}
   };
 


### PR DESCRIPTION
Live example in my project

States are:
profile - abstract
profile.index
profile.more

With this change I can easily show menu item as selected for all profile substates.
&lt;li ui-sref-active="active">&lt;a ui-sref="profile">profile&lt;/a>&lt;/li>

And setup default child in configuration.

.state('profile', {
  url : "/profile",
  abstract:true,
  templateUrl : '/app/profile.html',
  defaultChild : 'index',
}).
