### PR TITLE
Added transition options to event info

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -581,7 +581,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
        * })
        * </pre>
        */
-      var evt = $rootScope.$broadcast('$stateNotFound', redirect, state, params);
+      var evt = $rootScope.$broadcast('$stateNotFound', redirect, state, params, options);
 
       if (evt.defaultPrevented) {
         $urlRouter.update();
@@ -851,7 +851,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
          * })
          * </pre>
          */
-        if ($rootScope.$broadcast('$stateChangeStart', to.self, toParams, from.self, fromParams).defaultPrevented) {
+        if ($rootScope.$broadcast('$stateChangeStart', to.self, toParams, from.self, fromParams, options).defaultPrevented) {
           $urlRouter.update();
           return TransitionPrevented;
         }
@@ -929,7 +929,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
          * @param {State} fromState The current state, pre-transition.
          * @param {Object} fromParams The params supplied to the `fromState`.
          */
-          $rootScope.$broadcast('$stateChangeSuccess', to.self, toParams, from.self, fromParams);
+          $rootScope.$broadcast('$stateChangeSuccess', to.self, toParams, from.self, fromParams, options);
         }
         $urlRouter.update(true);
 
@@ -956,7 +956,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
          * @param {Object} fromParams The params supplied to the `fromState`.
          * @param {Error} error The resolve error object.
          */
-        evt = $rootScope.$broadcast('$stateChangeError', to.self, toParams, from.self, fromParams, error);
+        evt = $rootScope.$broadcast('$stateChangeError', to.self, toParams, from.self, fromParams, error, options);
 
         if (!evt.defaultPrevented) {
             $urlRouter.update();


### PR DESCRIPTION
I ran into a problem recently where I need to know in a $stateChangeStart event handler whether the transition will be a reload or not. I really only need the extra info on that event, but I figured I should keep everything consistent. Its added to the end so as not to break anything and most people can just act like its not even there.
