### PR TITLE
Exception when no state in uiRefActive

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -244,6 +244,8 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate) {
 
       // Update route state
       function update() {
+        if(angular.isUndefined(state)) 
+          throw 'StateRefActiveDirective cant find a valid ui-sref in ' + $element.context.innerHTML;
         if (isMatch()) {
           $element.addClass(activeClass);
         } else {


### PR DESCRIPTION
Hey,
Currently, when someone forgot tu put a ui-sref in the ui-sref-active, it just do an error.
It could be fine to avoid it and throw an exception with some indaction to resove it.

```
 <li ui-sref-active="active" ><a ng-click="some()">Thing</a></li>
```
