### PR TITLE
Allow multiple states to be registered at once

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -172,6 +172,12 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
   }
 
   function registerState(state) {
+    if (isArray(state)) {
+      for (var stateLen = state.length, stateIndex = 0; stateIndex < stateLen; stateIndex++) {
+        registerState(state[stateIndex]);
+      }
+      return;
+    }
     // Wrap a new object around the state so we can store our private details easily.
     state = inherit(state, {
       self: state,


### PR DESCRIPTION
e.g 
```js
$stateProvider.state([{
  name: 'a',
  url: 'a',
}, {
  name: 'b',
  url: 'b',
}]);
```
This is the way all other angular directives / config etc. coding style work