### PR TITLE
fix($urlRouter): resolve clashing of routes

### DIFF
--- a/src/urlRouter.js
+++ b/src/urlRouter.js
@@ -303,6 +303,12 @@ function $UrlRouterProvider(   $locationProvider,   $urlMatcherFactory) {
       return listener;
     }
 
+    rules.sort(function(ruleA, ruleB) {
+      var aLength = ruleA.prefix ? ruleA.prefix.length : 0;
+      var bLength = ruleB.prefix ? ruleB.prefix.length : 0;
+      return bLength - aLength;
+    });
+
     if (!interceptDeferred) listen();
 
     return {

--- a/test/urlRouterSpec.js
+++ b/test/urlRouterSpec.js
@@ -55,6 +55,8 @@ describe("UrlRouter", function () {
           return path.replace('baz', 'b4z');
         }).when('/foo/:param', function($match) {
           match = ['/foo/:param', $match];
+        }).when('/foo/bar', function($match) {
+          match = ['/foo/bar', $match];
         }).when('/bar', function($match) {
           match = ['/bar', $match];
         });
@@ -69,6 +71,18 @@ describe("UrlRouter", function () {
         $s = $injector.get('$sniffer');
         $s.history = true;
       });
+    });
+
+    it("should handle more specified url first", function() {
+      location.path("/foo/bar");
+      scope.$emit("$locationChangeSuccess");
+      expect(match[0]).toBe("/foo/bar");
+      expect(match[1]).toEqual({});
+
+      location.path("/foo/baz");
+      scope.$emit("$locationChangeSuccess");
+      expect(match[0]).toBe("/foo/:param");
+      expect(match[1]).toEqual({param: 'baz'});
     });
 
     it("should execute rewrite rules", function () {


### PR DESCRIPTION
Sometimes url can be matched by several different rules. Now it will be handled by the first rule in order of appearance. So it causes some issues. It would be better to match states from more specified to common.

Angular-route already has same issue https://github.com/angular/angular.js/issues/8266

So, I propose include this fixes here, because is ui-router more powerful and flexible library.