### PR TITLE
style(License): update copyright year to range

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2014 The AngularUI Team, Karsten Sperling
+Copyright (c) 2013-2015 The AngularUI Team, Karsten Sperling
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Copyright notices must reflect the current year. This commit updates the listed year to 2015 with a starting year of 2013.
https://github.com/angular-ui/ui-router/commit/2309474d479d2e27e0700db972a10862f4792a3f