### PR TITLE
fix($state): allow about.*.** glob patterns

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -215,6 +215,13 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
     var globSegments = glob.split('.'),
         segments = $state.$current.name.split('.');
 
+    //match single stars
+    for (var i = 0, l = globSegments.length; i < l; i++) {
+      if (globSegments[i] === '*') {
+        segments[i] = '*';
+      }
+    }
+
     //match greedy starts
     if (globSegments[0] === '**') {
        segments = segments.slice(indexOf(segments, globSegments[1]));
@@ -228,13 +235,6 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
 
     if (globSegments.length != segments.length) {
       return false;
-    }
-
-    //match single stars
-    for (var i = 0, l = globSegments.length; i < l; i++) {
-      if (globSegments[i] === '*') {
-        segments[i] = '*';
-      }
     }
 
     return segments.join('') === globSegments.join('');

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -612,6 +612,7 @@ describe('state', function () {
       expect($state.includes('*.*.*')).toBe(true);
       expect($state.includes('about.*.*')).toBe(true);
       expect($state.includes('about.**')).toBe(true);
+      expect($state.includes('about.*.**')).toBe(true);
       expect($state.includes('*.about.*')).toBe(false);
       expect($state.includes('about.*.*', {person: 'bob'})).toBe(true);
       expect($state.includes('about.*.*', {person: 'shawn'})).toBe(false);


### PR DESCRIPTION
Previously, it was not possible to match all descendant states without
matching the parent state.

e.g. `about.*.**` would not match state `about.person.item`

I want to be able to match all of the `about` child states, but not the `about` state.