### PR TITLE
Fix bool decoding for "0" value

### DIFF
--- a/src/urlMatcherFactory.js
+++ b/src/urlMatcherFactory.js
@@ -589,8 +589,14 @@ function $UrlMatcherFactory() {
       pattern: /\d+/
     },
     bool: {
-      encode: function(val) { return val ? 1 : 0; },
-      decode: function(val) { return parseInt(val, 10) !== 0; },
+      encode: function(val) {
+        if (!this.is(val)) return undefined;
+        return val ? 1 : 0;
+      },
+      decode: function(val) {
+        if (this.is(val)) return val;
+        return parseInt(val, 10) !== 0;
+      },
       is: function(val) { return val === true || val === false; },
       pattern: /0|1/
     },


### PR DESCRIPTION
Here's what's happening now:

1. Define a state with a bool param, e.g. `{foo:bool}`
2. Navigate to the URL with `?foo=0`
3. `$stateParams.foo === true`

Here's what goes on internally. `bool.decode` gets called twice, with the second call happening on the return value from the first. Not sure why, but it explains why at least some of the existing tests against this behavior aren't catching this. `?foo=1` works, but only because:

1. `'1'` comes in, `true` is returned
2. `true` comes in, `true` is returned b/c `NaN !== 0`

With `?foo=0`, the second call has `false` as `val`. Basically `bool.decode` is always going to return `true` if called twice. 

I'm borrowing the logic from the date parser/formatter.