### PR TITLE
Add spm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Check out the sample app: http://angular-ui.github.io/ui-router/sample/
  - [download the release](http://angular-ui.github.io/ui-router/release/angular-ui-router.js) (or [minified](http://angular-ui.github.io/ui-router/release/angular-ui-router.min.js))
  - via **[Bower](http://bower.io/)**: by running `$ bower install angular-ui-router` from your console
  - or via **[npm](https://www.npmjs.org/)**: by running `$ npm install angular-ui-router` from your console
+ - or via **[spm](https://spmjs.io/)**: by running `$ spm install angular-ui-router` from your console [![spm package](http://spmjs.io/badge/angular-ui-router)](http://spmjs.io/package/angular-ui-router)
  - or via **[Component](https://github.com/component/component)**: by running `$ component install angular-ui/ui-router` from your console
 
 **(2)** Include `angular-ui-router.js` (or `angular-ui-router.min.js`) in your `index.html`, after including Angular itself (For Component users: ignore this step)

--- a/package.json
+++ b/package.json
@@ -63,5 +63,16 @@
     "grunt-conventional-changelog": "~1.1.0",
     "grunt-ngdocs": "git://github.com/christopherthielen/grunt-ngdocs#issue-86"
   },
-  "main": "release/angular-ui-router.js"
+  "main": "release/angular-ui-router.js",
+  "spm": {
+    "main": "release/angular-ui-router.js",
+    "ignore": [
+      "api",
+      "lib",
+      "config",
+      "ngdoc_assets",
+      "sample",
+      "test"
+    ]
+  }
 }


### PR DESCRIPTION


A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/angular-ui-router

---

It is a browser-side package manager popular in China, suppling a complete lifecycle managment of package via [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of angular-ui-router in spmjs, I can add it for your account after signing in http://spmjs.io.

spmjs/spm#781
