### PR TITLE
fix($urlMatcherFactory): unquote all dashes from array params

### DIFF
--- a/src/urlMatcherFactory.js
+++ b/src/urlMatcherFactory.js
@@ -242,7 +242,7 @@ UrlMatcher.prototype.exec = function (path, searchParams) {
 
   function decodePathArray(string) {
     function reverseString(str) { return str.split("").reverse().join(""); }
-    function unquoteDashes(str) { return str.replace(/\\-/, "-"); }
+    function unquoteDashes(str) { return str.replace(/\\-/g, "-"); }
 
     var split = reverseString(string).split(/-(?!\\)/);
     var allReversed = map(split, reverseString);

--- a/test/urlMatcherFactorySpec.js
+++ b/test/urlMatcherFactorySpec.js
@@ -390,14 +390,21 @@ describe("UrlMatcher", function () {
       expect(m.format({ "param1[]": [] })).toEqual("/foo/");
       expect(m.format({ "param1[]": [ 'bar-' ] })).toEqual("/foo/bar%5C%2D");
       expect(m.format({ "param1[]": [ 'bar-', '-baz' ] })).toEqual("/foo/bar%5C%2D-%5C%2Dbaz");
+      expect(m.format({ "param1[]": [ 'bar-bar-bar-', '-baz-baz-baz' ] }))
+        .toEqual("/foo/bar%5C%2Dbar%5C%2Dbar%5C%2D-%5C%2Dbaz%5C%2Dbaz%5C%2Dbaz");
 
       // check that we handle $location.url decodes correctly
       $location.url(m.format({ "param1[]": [ 'bar-', '-baz' ] }));
       expect(m.exec($location.path(), $location.search())).toEqual({ "param1[]": [ 'bar-', '-baz' ] });
 
+      // check that we handle $location.url decodes correctly for multiple hyphens
+      $location.url(m.format({ "param1[]": [ 'bar-bar-bar-', '-baz-baz-baz' ] }));
+      expect(m.exec($location.path(), $location.search())).toEqual({ "param1[]": [ 'bar-bar-bar-', '-baz-baz-baz' ] });
+
       // check that pre-encoded values are passed correctly
       $location.url(m.format({ "param1[]": [ '%2C%20%5C%2C', '-baz' ] }));
       expect(m.exec($location.path(), $location.search())).toEqual({ "param1[]": [ '%2C%20%5C%2C', '-baz' ] });
+
     }));
   });
 });


### PR DESCRIPTION
I noticed when using an array of uuids in a URL that the URL Matcher would only unquote the first dash it found. The fix was pretty straight forward and I have added tests.