### PR TITLE
feat($IncludedByStateFilter): add parameters to $IncludedByStateFilter

### DIFF
--- a/src/stateFilters.js
+++ b/src/stateFilters.js
@@ -27,8 +27,8 @@ function $IsStateFilter($state) {
  */
 $IncludedByStateFilter.$inject = ['$state'];
 function $IncludedByStateFilter($state) {
-  var includesFilter = function (state) {
-    return $state.includes(state);
+  var includesFilter = function (state, params, options) {
+    return $state.includes(state, params, options);
   };
   includesFilter.$stateful = true;
   return  includesFilter;

--- a/test/stateFiltersSpec.js
+++ b/test/stateFiltersSpec.js
@@ -25,7 +25,8 @@ describe('includedByState filter', function() {
     $stateProvider
       .state('a', { url: '/' })
       .state('a.b', { url: '/b' })
-      .state('c', { url: '/c' });
+      .state('c', { url: '/c' })
+      .state('d', { url: '/d/:id' });
   }));
 
   it('should return true if the current state exactly matches the input state', inject(function($parse, $state, $q, $rootScope) {
@@ -44,5 +45,17 @@ describe('includedByState filter', function() {
     $state.go('c');
     $q.flush();
     expect($parse('"a" | includedByState')($rootScope)).toBe(false);
+  }));
+
+  it('should return true if the current state include input state and params', inject(function($parse, $state, $q, $rootScope) {
+    $state.go('d', { id: 123 });
+    $q.flush();
+    expect($parse('"d" | includedByState:{ id: 123 }')($rootScope)).toBe(true);
+  }));
+
+  it('should return false if the current state does not include input state and params', inject(function($parse, $state, $q, $rootScope) {
+    $state.go('d', { id: 2377 });
+    $q.flush();
+    expect($parse('"d" | includedByState:{ id: 123 }')($rootScope)).toBe(false);
   }));
 });


### PR DESCRIPTION
Add parameters to the $IncludedByStateFilter:
- params
- options

This allows to use more parameters on this filter and not only the `fullOrPartialStatename` parameter.
Thanks to this improvement, the following now works (takes in account the id param):

`<div ng-show="'**.foo.**' | includedByState:{id: 'new'}">It works</div>`

Closes #1735