### PR TITLE
feat(urlMatcherFactory): Added path param type to allow forward slashes in parameters, and not encode them

### DIFF
--- a/src/urlMatcherFactory.js
+++ b/src/urlMatcherFactory.js
@@ -342,7 +342,11 @@ UrlMatcher.prototype.format = function (values) {
       if (squash === false) {
         if (encoded != null) {
           if (isArray(encoded)) {
-            result += map(encoded, encodeDashes).join("-");
+            if (param.type.name == 'path') {
+              result += map(encoded, encodeURIComponent).join("/");
+            } else {
+              result += map(encoded, encodeDashes).join("-");
+            }
           } else {
             result += encodeURIComponent(encoded);
           }
@@ -619,6 +623,14 @@ function $UrlMatcherFactory() {
       is: angular.isObject,
       equals: angular.equals,
       pattern: /[^/]*/
+    },
+    path: {
+      encode: function(val) {
+        return val.split('/');
+      },
+      decode: angular.identity,
+      is: regexpMatches,
+      pattern: /.*/
     },
     any: { // does not encode/decode
       encode: angular.identity,

--- a/test/urlMatcherFactorySpec.js
+++ b/test/urlMatcherFactorySpec.js
@@ -530,6 +530,17 @@ describe("urlMatcherFactory", function () {
       expect(m.exec("/state/" + json1 + "/" + json2)).toEqual(params);
     });
 
+    it("should encode/decode path parameters without encoding the slashes", function () {
+      var m = new UrlMatcher("/{path:path}");
+      expect(m.exec("/some/path")).toEqual({ path: 'some/path' });
+      expect(m.format({ path: 'some/path' })).toBe('/some/path');
+    });
+
+    it("should encode path parameters with encoding of the path parameter components", function () {
+      var m = new UrlMatcher("/{path:path}");
+      expect(m.format({ path: 'some /path' })).toBe('/some%20/path');
+    });
+
     it("should not match invalid typed parameter values", function() {
       var m = new UrlMatcher('/users/{id:int}');
 


### PR DESCRIPTION
Solves #733

I couldn't see anywhere to add any documentation for the default types so I could add this to it. 

Please let me know if anything wants fixing, this is my first PR for angular.
