### PR TITLE
(chore): Add packaging for Meteor.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ bower_components
 
 # webstorm files
 .idea
+
+# Meteor package creation files
+.versions

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Check out the sample app: http://angular-ui.github.io/ui-router/sample/
  - or via **[npm](https://www.npmjs.org/)**: by running `$ npm install angular-ui-router` from your console
  - or via **[Bower](http://bower.io/)**: by running `$ bower install angular-ui-router` from your console
  - or via **[Component](https://github.com/component/component)**: by running `$ component install angular-ui/ui-router` from your console
+ - or via **[Meteor](https://www.meteor.com/): by running `meteor add angularui:angular-ui-router`.
 
 **(2)** Include `angular-ui-router.js` (or `angular-ui-router.min.js`) in your `index.html`, after including Angular itself (For Component users: ignore this step)
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 // package metadata file for Meteor.js
 var packageName = 'angularui:angular-ui-router'; // https://atmospherejs.com/angularui/angular-ui-router
 var where = 'client'; // where to install: 'client' or 'server'. For both, pass nothing.
-var version = '0.2.13_3';
+var version = '0.2.14';
 
 Package.describe({
   name: packageName,

--- a/package.js
+++ b/package.js
@@ -1,0 +1,20 @@
+// package metadata file for Meteor.js
+var packageName = 'angularui:angular-ui-router'; // https://atmospherejs.com/angularui/angular-ui-router
+var where = 'client'; // where to install: 'client' or 'server'. For both, pass nothing.
+var version = '0.2.13_3';
+
+Package.describe({
+  name: packageName,
+  version: version,
+  summary: 'angular-ui-router (official): Flexible routing with nested views in AngularJS',
+  git: 'git@github.com:angular-ui/ui-router.git',
+  documentation: null
+});
+
+Package.onUse(function(api) {
+  api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
+
+  api.use('angular:angular@1.0.8', where);
+
+  api.addFiles('release/angular-ui-router.js', where);
+});

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 // package metadata file for Meteor.js
 var packageName = 'angularui:angular-ui-router'; // https://atmospherejs.com/angularui/angular-ui-router
 var where = 'client'; // where to install: 'client' or 'server'. For both, pass nothing.
-var version = '0.2.14';
+var version = '0.2.15';
 
 Package.describe({
   name: packageName,

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "grunt-karma": "~0.6.2",
     "shelljs": "~0.2.6",
     "faithful-exec": "~0.1.0",
+    "grunt-exec": "^0.4.6",
     "karma-firefox-launcher": "~0.1.0",
     "karma-chrome-launcher": "~0.1.0",
     "karma-html2js-preprocessor": "~0.1.0",


### PR DESCRIPTION
Hi @nateabele @christopherthielen 

I'm a package maintainer for [Meteor.js](https://www.meteor.com/), a popular [full-stack JavaScript framework](https://github.com/meteor/meteor).

I'm also the creator of [angular-meteor](http://angularjs.meteor.com/), a library that let's you work with AngularJS on top of Meteor.

A lot of our users use ui-router and it right now there is a separate package and Github repo that simply manually copies your distribution and publish it to Meteor.
This PR will allow you to directly publish updated versions of ui-router as they become available. All you have to do is create an account at https://meteor.com/ (click SIGN IN, then Create account). After you've done that, please let me know the name of the account, and I'll add you as a maintainer to the angularui organization there.

I've already published the current version of the package on Atmosphere (Meteor's package directory). When you release new versions of ui-router, you'll be able to publish them to Atmosphere by running make meteor.

Thanks & best regards,
Uri