### PR TITLE
use $templateRequest instead of $http directly

### DIFF
--- a/src/templateFactory.js
+++ b/src/templateFactory.js
@@ -9,8 +9,8 @@
  * @description
  * Service. Manages loading of templates.
  */
-$TemplateFactory.$inject = ['$http', '$templateCache', '$injector'];
-function $TemplateFactory(  $http,   $templateCache,   $injector) {
+$TemplateFactory.$inject = ['$http', '$templateCache', '$templateRequest', '$injector'];
+function $TemplateFactory(  $http,   $templateCache, $templateRequest,  $injector) {
 
   /**
    * @ngdoc function
@@ -82,8 +82,7 @@ function $TemplateFactory(  $http,   $templateCache,   $injector) {
   this.fromUrl = function (url, params) {
     if (isFunction(url)) url = url(params);
     if (url == null) return null;
-    else return $http
-        .get(url, { cache: $templateCache, headers: { Accept: 'text/html' }})
+    else return $templateRequest(url)
         .then(function(response) { return response.data; });
   };
 


### PR DESCRIPTION
In the angular core, $templateRequest is used instead of $http directly for fetching a template.

See ngRoute:

https://github.com/angular/angular.js/blob/master/src/ngRoute/route.js#L595

As well as ngInclude:

https://github.com/angular/angular.js/blob/3ae79c0105cbf58530dfb2d48865f25dcf2d3a2b/src/ng/directive/ngInclude.js#L229

$templateRequest internally calls $http with the $templateCache:

https://github.com/angular/angular.js/blob/f6272333127d908b19da23f9cd8a74052711795b/src/ng/templateRequest.js#L42