### PR TITLE
Handle opening in new tab on command-click; fixes #1797

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -134,7 +134,13 @@ function $StateRefDirective($state, $timeout) {
         if ( !(button > 1 || e.ctrlKey || e.metaKey || e.shiftKey || element.attr('target')) ) {
           // HACK: This is to allow ng-clicks to be processed before the transition is initiated:
           var transition = $timeout(function() {
-            $state.go(ref.state, params, options);
+            if (e.metaKey) {
+              options.absolute = true;
+              var url = $state.href(ref.state, params, options);
+              window.open(url,'_blank');
+            } else {
+              $state.go(ref.state, params, options);
+            }
           });
           e.preventDefault();
 


### PR DESCRIPTION
For non-anchor tags, command-click is ignored for opening in a new tab. This checks if the command key is down and uses window.open in combination with $state.href to properly open a ui-sref in a new tab on a non-anchor element.