### PR TITLE
feat($state): added 'state' to state reload method (feat no.1612)

### DIFF
--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -113,7 +113,30 @@ describe('state', function () {
       // State param inheritance tests. param1 is inherited by sub1 & sub2;
       // param2 should not be transferred (unless explicitly set).
       .state('root', { url: '^/root?param1' })
-      .state('root.sub1', {url: '/1?param2' });
+      .state('root.sub1', {url: '/1?param2' })
+      .state('logA', {
+        url: "/logA",
+        template: "<div> <div ui-view/></div>",
+        controller: function() {log += "logA;"}
+      })
+      .state('logA.logB', {
+        url: "/logB",
+        views:{
+          '':{
+                template: "<div> <div ui-view/></div>",
+                controller: function() {log += "logB;"}
+          }
+        }
+      })
+      .state('logA.logB.logC', {
+        url: "/logC",
+        views:{
+          '':{
+                template: "<div> <div ui-view/></div>",
+                controller: function() {log += "logC;"}
+          }
+        }
+      })
     $stateProvider.state('root.sub2', {url: '/2?param2' });
 
     $provide.value('AppInjectable', AppInjectable);
@@ -531,6 +554,92 @@ describe('state', function () {
       $q.flush();
       expect(log).toBe('Success!controller;Success!controller;');
     }));
+
+    it('should invoke the controllers by state when given state name', inject(function ($state, $q, $timeout, $rootScope, $compile) {
+      $compile('<div> <div ui-view/></div>')($rootScope);
+      $state.transitionTo('logA.logB.logC');
+      $q.flush();
+      expect(log).toBe('logA;logB;logC;');
+
+      log = '';
+      $state.reload('logA');
+      $q.flush();
+      expect(log).toBe('logA;logB;logC;');
+
+      log = '';
+      $state.reload('logA.logB');
+      $q.flush();
+      expect(log).toBe('logB;logC;');
+
+      log = '';
+      $state.reload('logA.logB.logC');
+      $q.flush();
+      expect(log).toBe('logC;');
+    }));
+
+    it('should reload all states when passing false', inject(function ($state, $q, $timeout, $rootScope, $compile) {
+      $compile('<div> <div ui-view/></div>')($rootScope);
+      $state.transitionTo('logA.logB.logC');
+      $q.flush();
+      expect(log).toBe('logA;logB;logC;');
+
+      log = '';
+      $state.reload(false);
+      $q.flush();
+      expect(log).toBe('logA;logB;logC;');
+    }));
+
+    it('should reload all states when passing true', inject(function ($state, $q, $timeout, $rootScope, $compile) {
+      $compile('<div> <div ui-view/></div>')($rootScope);
+      $state.transitionTo('logA.logB.logC');
+      $q.flush();
+      expect(log).toBe('logA;logB;logC;');
+
+      log = '';
+      $state.reload(true);
+      $q.flush();
+      expect(log).toBe('logA;logB;logC;');
+    }));
+
+
+    it('should invoke the controllers by state when given stateObj', inject(function ($state, $q, $timeout, $rootScope, $compile) {
+      $compile('<div> <div ui-view/></div>')($rootScope);
+      $state.transitionTo('logA.logB.logC');
+
+      $q.flush();
+      expect(log).toBe('logA;logB;logC;');
+
+      log = '';
+      $state.reload($state.current);
+      $q.flush();
+      expect(log).toBe('logC;');
+    }));
+
+    it('should throw an exception for invalid reload state name', inject(function ($state, $q, $timeout, $rootScope, $compile) {
+      $compile('<div> <div ui-view/></div>')($rootScope);
+      $state.transitionTo('logA.logB.logC');
+      $q.flush();
+      expect(log).toBe('logA;logB;logC;');
+
+      expect(function(){
+          $state.reload('logInvalid')}
+        ).toThrow("No such reload state 'logInvalid'");
+    }));
+
+    it('should throw an exception for invalid reload state object', inject(function ($state, $q, $timeout, $rootScope, $compile) {
+      $compile('<div> <div ui-view/></div>')($rootScope);
+      $state.transitionTo('logA.logB.logC');
+      $q.flush();
+      expect(log).toBe('logA;logB;logC;');
+
+      expect(function(){
+          $state.reload({foo:'bar'})}
+        ).toThrow("Invalid reload state object");
+
+      expect(function(){
+          $state.reload({name:'invalidState'})}
+        ).toThrow("No such reload state 'invalidState'");
+    }));
   });
 
   describe('.is()', function () {
@@ -784,6 +893,9 @@ describe('state', function () {
         'home.item',
         'home.redirect',
         'json',
+        'logA',
+        'logA.logB',
+        'logA.logB.logC',
         'resolveFail',
         'resolveTimeout',
         'root',


### PR DESCRIPTION
 - modiefied options.reload parameter in transitionTo method to accept the
   following:
   {reload : true} will reload all states
   {reload : 'foo.bar'} will reload foo.bar, and any children
   {reload : stateObj} will reload state found in stateObj, and any
   children.
 - added 'state' parameter(string|object) to $state.reload method,
   to be passed to $state.transitionTo method as the reload option.
 - test the $state.reload with state parameter