### PR TITLE
Fix critical bug - routing stop working in some cases

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -96,7 +96,7 @@ function inheritParams(currentParams, newParams, $current, $to) {
   var parents = ancestors($current, $to), parentParams, inherited = {}, inheritList = [];
 
   for (var i in parents) {
-    if (!parents[i].params) continue;
+    if (!parents[i] || !parents[i].params) continue;
     parentParams = objectKeys(parents[i].params);
     if (!parentParams.length) continue;
 


### PR DESCRIPTION
I don't know how it's possible, but in all browsers I see exception with message about .params of undefined.
This is a small, simple and safe fix.