### PR TITLE
feat($state): broadcast $stateChangeCancel event when event.preventDefau

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -1028,6 +1028,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
          * </pre>
          */
         if ($rootScope.$broadcast('$stateChangeStart', to.self, toParams, from.self, fromParams).defaultPrevented) {
+          $rootScope.$broadcast('$stateChangeCancel', to.self, toParams, from.self, fromParams);
           $urlRouter.update();
           return TransitionPrevented;
         }

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -123,6 +123,7 @@ describe('state', function () {
     log = '';
     logEvents = logEnterExit = false;
     $rootScope.$on('$stateChangeStart', eventLogger);
+    $rootScope.$on('$stateChangeCancel', eventLogger);
     $rootScope.$on('$stateChangeSuccess', eventLogger);
     $rootScope.$on('$stateChangeError', eventLogger);
     $rootScope.$on('$stateNotFound', eventLogger);
@@ -211,6 +212,25 @@ describe('state', function () {
       var promise = $state.transitionTo(B, {});
       $q.flush();
       expect(called).toBeTruthy();
+      expect($state.current).toBe(A);
+      expect(resolvedError(promise)).toBeTruthy();
+    }));
+
+    it('can be cancelled by preventDefault() in $stateChangeStart and broadcasts $stateChangeCancel', inject(function ($state, $q, $rootScope) {
+      initStateTo(A);
+      var called, cancelEventCalled;
+      $rootScope.$on('$stateChangeStart', function (ev) {
+        ev.preventDefault();
+        called = true;
+      });
+      $rootScope.$on('$stateChangeCancel', function (ev) {
+        ev.preventDefault();
+        cancelEventCalled = true;
+      });
+      var promise = $state.transitionTo(B, {});
+      $q.flush();
+      expect(called).toBeTruthy();
+      expect(cancelEventCalled).toBeTruthy();
       expect($state.current).toBe(A);
       expect(resolvedError(promise)).toBeTruthy();
     }));


### PR DESCRIPTION
After preventDefault is fired in stateChangeStart, a stageChangeCancel event will be launched.

Rebased and squashed version of #1090 as requested (original PR wasn't mine).