### PR TITLE
feat($state): add $stateChangeValidation event

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -141,9 +141,9 @@ module.exports = function (grunt) {
   grunt.registerTask('widedocs', 'Convert to bootstrap container-fluid', function () {
     promising(this,
       system(
-      'sed -i.bak ' + 
-      '-e \'s/class="row"/class="row-fluid"/\' ' + 
-      '-e \'s/icon-cog"><\\/i>/icon-cog"><\\/i>Provider/\' ' + 
+      'sed -i.bak ' +
+      '-e \'s/class="row"/class="row-fluid"/\' ' +
+      '-e \'s/icon-cog"><\\/i>/icon-cog"><\\/i>Provider/\' ' +
       '-e \'s/role="main" class="container"/role="main" class="container-fluid"/\' site/index.html')
     );
   });

--- a/src/state.js
+++ b/src/state.js
@@ -122,7 +122,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
     if (path) {
       if (!base) throw new Error("No reference point given for path '"  + name + "'");
       base = findState(base);
-      
+
       var rel = name.split("."), i = 0, pathLength = rel.length, current = base;
 
       for (; i < pathLength; i++) {
@@ -257,9 +257,9 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
    * @methodOf ui.router.state.$stateProvider
    *
    * @description
-   * Allows you to extend (carefully) or override (at your own peril) the 
-   * `stateBuilder` object used internally by `$stateProvider`. This can be used 
-   * to add custom functionality to ui-router, for example inferring templateUrl 
+   * Allows you to extend (carefully) or override (at your own peril) the
+   * `stateBuilder` object used internally by `$stateProvider`. This can be used
+   * to add custom functionality to ui-router, for example inferring templateUrl
    * based on the state name.
    *
    * When passing only a name, it returns the current (original or decorated) builder
@@ -268,14 +268,14 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
    * The builder functions that can be decorated are listed below. Though not all
    * necessarily have a good use case for decoration, that is up to you to decide.
    *
-   * In addition, users can attach custom decorators, which will generate new 
-   * properties within the state's internal definition. There is currently no clear 
-   * use-case for this beyond accessing internal states (i.e. $state.$current), 
-   * however, expect this to become increasingly relevant as we introduce additional 
+   * In addition, users can attach custom decorators, which will generate new
+   * properties within the state's internal definition. There is currently no clear
+   * use-case for this beyond accessing internal states (i.e. $state.$current),
+   * however, expect this to become increasingly relevant as we introduce additional
    * meta-programming features.
    *
-   * **Warning**: Decorators should not be interdependent because the order of 
-   * execution of the builder functions in non-deterministic. Builder functions 
+   * **Warning**: Decorators should not be interdependent because the order of
+   * execution of the builder functions in non-deterministic. Builder functions
    * should only be dependent on the state definition object and super function.
    *
    *
@@ -286,21 +286,21 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
    *   overridden by own values (if any).
    * - **url** `{object}` - returns a {@link ui.router.util.type:UrlMatcher UrlMatcher}
    *   or `null`.
-   * - **navigable** `{object}` - returns closest ancestor state that has a URL (aka is 
+   * - **navigable** `{object}` - returns closest ancestor state that has a URL (aka is
    *   navigable).
-   * - **params** `{object}` - returns an array of state params that are ensured to 
+   * - **params** `{object}` - returns an array of state params that are ensured to
    *   be a super-set of parent's params.
-   * - **views** `{object}` - returns a views object where each key is an absolute view 
-   *   name (i.e. "viewName@stateName") and each value is the config object 
-   *   (template, controller) for the view. Even when you don't use the views object 
+   * - **views** `{object}` - returns a views object where each key is an absolute view
+   *   name (i.e. "viewName@stateName") and each value is the config object
+   *   (template, controller) for the view. Even when you don't use the views object
    *   explicitly on a state config, one is still created for you internally.
-   *   So by decorating this builder function you have access to decorating template 
+   *   So by decorating this builder function you have access to decorating template
    *   and controller properties.
-   * - **ownParams** `{object}` - returns an array of params that belong to the state, 
+   * - **ownParams** `{object}` - returns an array of params that belong to the state,
    *   not including any params defined by ancestor states.
-   * - **path** `{string}` - returns the full path from the root down to this state. 
+   * - **path** `{string}` - returns the full path from the root down to this state.
    *   Needed for state activation.
-   * - **includes** `{object}` - returns an object that includes every state that 
+   * - **includes** `{object}` - returns an object that includes every state that
    *   would pass a `$state.includes()` test.
    *
    * @example
@@ -333,8 +333,8 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
    * // and /partials/home/contact/item.html, respectively.
    * </pre>
    *
-   * @param {string} name The name of the builder function to decorate. 
-   * @param {object} func A function that is responsible for decorating the original 
+   * @param {string} name The name of the builder function to decorate.
+   * @param {object} func A function that is responsible for decorating the original
    * builder function. The function receives two parameters:
    *
    *   - `{object}` - state - The state config object.
@@ -373,9 +373,9 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
    * @param {string|function=} stateConfig.template
    * <a id='template'></a>
    *   html template as a string or a function that returns
-   *   an html template as a string which should be used by the uiView directives. This property 
+   *   an html template as a string which should be used by the uiView directives. This property
    *   takes precedence over templateUrl.
-   *   
+   *
    *   If `template` is a function, it will be called with the following parameters:
    *
    *   - {array.&lt;object&gt;} - state parameters extracted from the current $location.path() by
@@ -393,10 +393,10 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
    *
    *   path or function that returns a path to an html
    *   template that should be used by uiView.
-   *   
+   *
    *   If `templateUrl` is a function, it will be called with the following parameters:
    *
-   *   - {array.&lt;object&gt;} - state parameters extracted from the current $location.path() by 
+   *   - {array.&lt;object&gt;} - state parameters extracted from the current $location.path() by
    *     applying the current state
    *
    * <pre>templateUrl: "home.html"</pre>
@@ -440,7 +440,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
    *
    * @param {string=} stateConfig.controllerAs
    * <a id='controllerAs'></a>
-   * 
+   *
    * A controller alias name. If present the controller will be
    *   published to scope under the controllerAs name.
    * <pre>controllerAs: "myCtrl"</pre>
@@ -456,17 +456,17 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
    * <a id='resolve'></a>
    *
    * An optional map&lt;string, function&gt; of dependencies which
-   *   should be injected into the controller. If any of these dependencies are promises, 
+   *   should be injected into the controller. If any of these dependencies are promises,
    *   the router will wait for them all to be resolved before the controller is instantiated.
    *   If all the promises are resolved successfully, the $stateChangeSuccess event is fired
    *   and the values of the resolved promises are injected into any controllers that reference them.
    *   If any  of the promises are rejected the $stateChangeError event is fired.
    *
    *   The map object is:
-   *   
+   *
    *   - key - {string}: name of dependency to be injected into controller
-   *   - factory - {string|function}: If string then it is alias for service. Otherwise if function, 
-   *     it is injected and return value it treated as dependency. If result is a promise, it is 
+   *   - factory - {string|function}: If string then it is alias for service. Otherwise if function,
+   *     it is injected and return value it treated as dependency. If result is a promise, it is
    *     resolved before its value is injected into controller.
    *
    * <pre>resolve: {
@@ -480,7 +480,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
    * <a id='url'></a>
    *
    *   A url fragment with optional parameters. When a state is navigated or
-   *   transitioned to, the `$stateParams` service will be populated with any 
+   *   transitioned to, the `$stateParams` service will be populated with any
    *   parameters that were passed.
    *
    *   (See {@link ui.router.util.type:UrlMatcher UrlMatcher} `UrlMatcher`} for
@@ -563,7 +563,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
    * <a id='reloadOnSearch'></a>
    *
    * If `false`, will not retrigger the same state
-   *   just because a search/query parameter has changed (via $location.search() or $location.hash()). 
+   *   just because a search/query parameter has changed (via $location.search() or $location.hash()).
    *   Useful for when you'd like to modify $location.search() without triggering a reload.
    * <pre>reloadOnSearch: false</pre>
    *
@@ -698,11 +698,11 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
    * @requires ui.router.state.$stateParams
    * @requires ui.router.router.$urlRouter
    *
-   * @property {object} params A param object, e.g. {sectionId: section.id)}, that 
+   * @property {object} params A param object, e.g. {sectionId: section.id)}, that
    * you'd like to test against the current active state.
-   * @property {object} current A reference to the state's config object. However 
+   * @property {object} current A reference to the state's config object. However
    * you passed it in. Useful for accessing custom data.
-   * @property {object} transition Currently pending transition. A promise that'll 
+   * @property {object} transition Currently pending transition. A promise that'll
    * resolve or reject.
    *
    * @description
@@ -815,7 +815,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
      *
      * `reload()` is just an alias for:
      * <pre>
-     * $state.transitionTo($state.current, $stateParams, { 
+     * $state.transitionTo($state.current, $stateParams, {
      *   reload: true, inherit: false, notify: true
      * });
      * </pre>
@@ -823,7 +823,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
      * @param {string=|object=} state - A state name or a state object, which is the root of the resolves to be re-resolved.
      * @example
      * <pre>
-     * //assuming app application consists of 3 states: 'contacts', 'contacts.detail', 'contacts.detail.item' 
+     * //assuming app application consists of 3 states: 'contacts', 'contacts.detail', 'contacts.detail.item'
      * //and current state is 'contacts.detail.item'
      * var app angular.module('app', ['ui.router']);
      *
@@ -837,7 +837,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
      *
      * `reload()` is just an alias for:
      * <pre>
-     * $state.transitionTo($state.current, $stateParams, { 
+     * $state.transitionTo($state.current, $stateParams, {
      *   reload: true, inherit: false, notify: true
      * });
      * </pre>
@@ -855,11 +855,11 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
      * @methodOf ui.router.state.$state
      *
      * @description
-     * Convenience method for transitioning to a new state. `$state.go` calls 
-     * `$state.transitionTo` internally but automatically sets options to 
-     * `{ location: true, inherit: true, relative: $state.$current, notify: true }`. 
-     * This allows you to easily use an absolute or relative to path and specify 
-     * only the parameters you'd like to update (while letting unspecified parameters 
+     * Convenience method for transitioning to a new state. `$state.go` calls
+     * `$state.transitionTo` internally but automatically sets options to
+     * `{ location: true, inherit: true, relative: $state.$current, notify: true }`.
+     * This allows you to easily use an absolute or relative to path and specify
+     * only the parameters you'd like to update (while letting unspecified parameters
      * inherit from the currently active ancestor states).
      *
      * @example
@@ -881,8 +881,8 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
      * - `$state.go('^.sibling')` - will go to a sibling state
      * - `$state.go('.child.grandchild')` - will go to grandchild state
      *
-     * @param {object=} params A map of the parameters that will be sent to the state, 
-     * will populate $stateParams. Any parameters that are not specified will be inherited from currently 
+     * @param {object=} params A map of the parameters that will be sent to the state,
+     * will populate $stateParams. Any parameters that are not specified will be inherited from currently
      * defined parameters. This allows, for example, going to a sibling state that shares parameters
      * specified in a parent state. Parameter inheritance only works between common ancestor states, I.e.
      * transitioning to a sibling will get you the parameters for all parents, transitioning to a child
@@ -892,10 +892,10 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
      * - **`location`** - {boolean=true|string=} - If `true` will update the url in the location bar, if `false`
      *    will not. If string, must be `"replace"`, which will update url and also replace last history record.
      * - **`inherit`** - {boolean=true}, If `true` will inherit url parameters from current url.
-     * - **`relative`** - {object=$state.$current}, When transitioning with relative path (e.g '^'), 
+     * - **`relative`** - {object=$state.$current}, When transitioning with relative path (e.g '^'),
      *    defines which state to be relative from.
      * - **`notify`** - {boolean=true}, If `true` will broadcast $stateChangeStart and $stateChangeSuccess events.
-     * - **`reload`** (v0.2.5) - {boolean=false}, If `true` will force transition even if the state or params 
+     * - **`reload`** (v0.2.5) - {boolean=false}, If `true` will force transition even if the state or params
      *    have not changed, aka a reload of the same state. It differs from reloadOnSearch because you'd
      *    use this when you want to force a reload when *everything* is the same, including search params.
      *
@@ -947,10 +947,10 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
      * - **`location`** - {boolean=true|string=} - If `true` will update the url in the location bar, if `false`
      *    will not. If string, must be `"replace"`, which will update url and also replace last history record.
      * - **`inherit`** - {boolean=false}, If `true` will inherit url parameters from current url.
-     * - **`relative`** - {object=}, When transitioning with relative path (e.g '^'), 
+     * - **`relative`** - {object=}, When transitioning with relative path (e.g '^'),
      *    defines which state to be relative from.
      * - **`notify`** - {boolean=true}, If `true` will broadcast $stateChangeStart and $stateChangeSuccess events.
-     * - **`reload`** (v0.2.5) - {boolean=false|string=|object=}, If `true` will force transition even if the state or params 
+     * - **`reload`** (v0.2.5) - {boolean=false|string=|object=}, If `true` will force transition even if the state or params
      *    have not changed, aka a reload of the same state. It differs from reloadOnSearch because you'd
      *    use this when you want to force a reload when *everything* is the same, including search params.
      *    if String, then will reload the state with the name given in reload, and any children.
@@ -1013,7 +1013,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
         if (isObject(options.reload) && !options.reload.name) {
           throw new Error('Invalid reload state object');
         }
-        
+
         var reloadState = options.reload === true ? fromPath[0] : findState(options.reload);
         if (options.reload && !reloadState) {
           throw new Error("No such reload state '" + (isString(options.reload) ? options.reload : options.reload.name) + "'");
@@ -1048,154 +1048,233 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       // Filter parameters before we pass them to event handlers etc.
       toParams = filterByKeys(to.params.$$keys(), toParams || {});
 
-      // Broadcast start event and cancel the transition if requested
+      // We're going to validate the state
+      var validators = [];
+
+      function cancelStateChange() {
+        $rootScope.$broadcast('$stateChangeCancel', to.self, toParams, from.self, fromParams);
+        $urlRouter.update();
+        return TransitionPrevented;
+      }
+
+      function registerValidator(value) {
+        validators.push($q.when(value));
+      }
+
+      function isTruthy(value) {
+        return Boolean(value);
+      }
+
+      function validateStateChange() {
+
+        if (!validators.length)
+          return proceedStateChange();
+
+        return $q.all(validators).then(function (validations) {
+            console.log( validations );
+          if (validations.every(isTruthy)) {
+            return proceedStateChange();
+          } else {
+            return cancelStateChange();
+          }
+        });
+
+      }
+
       if (options.notify) {
         /**
          * @ngdoc event
-         * @name ui.router.state.$state#$stateChangeStart
+         * @name ui.router.state.$state#$stateChangeValidation
          * @eventOf ui.router.state.$state
          * @eventType broadcast on root scope
          * @description
-         * Fired when the state transition **begins**. You can use `event.preventDefault()`
-         * to prevent the transition from happening and then the transition promise will be
-         * rejected with a `'transition prevented'` value.
+         * Fired **before** the state transition begins. You can use the `registerValidator`
+         * function to pause the transition execution and possibly cancel it.
+         *
+         * The `registerValidation` function takes a single parameter, which may be a promise
+         * (in which case it will be resolved, and its return value will be used as actual
+         * validator). If at least one falsy validator is registered, the state transition
+         * will be cancelled, and the transition promise will be rejected with a
+         * `'transition prevented'` value.
+         *
+         * You may ignore the validation (and thus force the state transition) by calling
+         * `event.preventDefault()` from one of the listeners.
          *
          * @param {Object} event Event object.
          * @param {State} toState The state being transitioned to.
          * @param {Object} toParams The params supplied to the `toState`.
          * @param {State} fromState The current state, pre-transition.
          * @param {Object} fromParams The params supplied to the `fromState`.
+         * @param {Function} registerValidator A function to register a new validator.
          *
          * @example
          *
          * <pre>
-         * $rootScope.$on('$stateChangeStart',
-         * function(event, toState, toParams, fromState, fromParams){
-         *     event.preventDefault();
-         *     // transitionTo() promise will be rejected with
-         *     // a 'transition prevented' error
+         * $rootScope.$on('$stateChangeValidation',
+         * function(event, toState, toParams, fromState, fromParams, registerValidator){
+         *   registerValidator(toState.enabled);
          * })
          * </pre>
          */
-        if ($rootScope.$broadcast('$stateChangeStart', to.self, toParams, from.self, fromParams).defaultPrevented) {
-          $rootScope.$broadcast('$stateChangeCancel', to.self, toParams, from.self, fromParams);
-          $urlRouter.update();
-          return TransitionPrevented;
+        if ($rootScope.$broadcast('$stateChangeValidation', to.self, toParams, from.self, fromParams, registerValidator).defaultPrevented) {
+          validators.length = 0;
         }
       }
 
-      // Resolve locals for the remaining states, but don't update any global state just
-      // yet -- if anything fails to resolve the current state needs to remain untouched.
-      // We also set up an inheritance chain for the locals here. This allows the view directive
-      // to quickly look up the correct definition for each view in the current state. Even
-      // though we create the locals object itself outside resolveState(), it is initially
-      // empty and gets filled asynchronously. We need to keep track of the promise for the
-      // (fully resolved) current locals, and pass this down the chain.
-      var resolved = $q.when(locals);
+      return validateStateChange();
 
-      for (var l = keep; l < toPath.length; l++, state = toPath[l]) {
-        locals = toLocals[l] = inherit(locals);
-        resolved = resolveState(state, toParams, state === to, resolved, locals, options);
-      }
+      function proceedStateChange() {
 
-      // Once everything is resolved, we are ready to perform the actual transition
-      // and return a promise for the new state. We also keep track of what the
-      // current promise is, so that we can detect overlapping transitions and
-      // keep only the outcome of the last transition.
-      var transition = $state.transition = resolved.then(function () {
-        var l, entering, exiting;
-
-        if ($state.transition !== transition) return TransitionSuperseded;
-
-        // Exit 'from' states not kept
-        for (l = fromPath.length - 1; l >= keep; l--) {
-          exiting = fromPath[l];
-          if (exiting.self.onExit) {
-            $injector.invoke(exiting.self.onExit, exiting.self, exiting.locals.globals);
-          }
-          exiting.locals = null;
-        }
-
-        // Enter 'to' states not kept
-        for (l = keep; l < toPath.length; l++) {
-          entering = toPath[l];
-          entering.locals = toLocals[l];
-          if (entering.self.onEnter) {
-            $injector.invoke(entering.self.onEnter, entering.self, entering.locals.globals);
-          }
-        }
-
-        // Re-add the saved hash before we start returning things
-        if (hash) toParams['#'] = hash;
-
-        // Run it again, to catch any transitions in callbacks
-        if ($state.transition !== transition) return TransitionSuperseded;
-
-        // Update globals in $state
-        $state.$current = to;
-        $state.current = to.self;
-        $state.params = toParams;
-        copy($state.params, $stateParams);
-        $state.transition = null;
-
-        if (options.location && to.navigable) {
-          $urlRouter.push(to.navigable.url, to.navigable.locals.globals.$stateParams, {
-            $$avoidResync: true, replace: options.location === 'replace'
-          });
-        }
-
+        // Broadcast start event and cancel the transition if requested
         if (options.notify) {
-        /**
-         * @ngdoc event
-         * @name ui.router.state.$state#$stateChangeSuccess
-         * @eventOf ui.router.state.$state
-         * @eventType broadcast on root scope
-         * @description
-         * Fired once the state transition is **complete**.
-         *
-         * @param {Object} event Event object.
-         * @param {State} toState The state being transitioned to.
-         * @param {Object} toParams The params supplied to the `toState`.
-         * @param {State} fromState The current state, pre-transition.
-         * @param {Object} fromParams The params supplied to the `fromState`.
-         */
-          $rootScope.$broadcast('$stateChangeSuccess', to.self, toParams, from.self, fromParams);
-        }
-        $urlRouter.update(true);
-
-        return $state.current;
-      }, function (error) {
-        if ($state.transition !== transition) return TransitionSuperseded;
-
-        $state.transition = null;
-        /**
-         * @ngdoc event
-         * @name ui.router.state.$state#$stateChangeError
-         * @eventOf ui.router.state.$state
-         * @eventType broadcast on root scope
-         * @description
-         * Fired when an **error occurs** during transition. It's important to note that if you
-         * have any errors in your resolve functions (javascript errors, non-existent services, etc)
-         * they will not throw traditionally. You must listen for this $stateChangeError event to
-         * catch **ALL** errors.
-         *
-         * @param {Object} event Event object.
-         * @param {State} toState The state being transitioned to.
-         * @param {Object} toParams The params supplied to the `toState`.
-         * @param {State} fromState The current state, pre-transition.
-         * @param {Object} fromParams The params supplied to the `fromState`.
-         * @param {Error} error The resolve error object.
-         */
-        evt = $rootScope.$broadcast('$stateChangeError', to.self, toParams, from.self, fromParams, error);
-
-        if (!evt.defaultPrevented) {
+          /**
+           * @ngdoc event
+           * @name ui.router.state.$state#$stateChangeStart
+           * @eventOf ui.router.state.$state
+           * @eventType broadcast on root scope
+           * @description
+           * Fired when the state transition **begins**. You can use `event.preventDefault()`
+           * to prevent the transition from happening and then the transition promise will be
+           * rejected with a `'transition prevented'` value.
+           *
+           * @param {Object} event Event object.
+           * @param {State} toState The state being transitioned to.
+           * @param {Object} toParams The params supplied to the `toState`.
+           * @param {State} fromState The current state, pre-transition.
+           * @param {Object} fromParams The params supplied to the `fromState`.
+           *
+           * @example
+           *
+           * <pre>
+           * $rootScope.$on('$stateChangeStart',
+           * function(event, toState, toParams, fromState, fromParams){
+           *     event.preventDefault();
+           *     // transitionTo() promise will be rejected with
+           *     // a 'transition prevented' error
+           * })
+           * </pre>
+           */
+          if ($rootScope.$broadcast('$stateChangeStart', to.self, toParams, from.self, fromParams).defaultPrevented) {
+            $rootScope.$broadcast('$stateChangeCancel', to.self, toParams, from.self, fromParams);
             $urlRouter.update();
+            return TransitionPrevented;
+          }
         }
 
-        return $q.reject(error);
-      });
+        // Resolve locals for the remaining states, but don't update any global state just
+        // yet -- if anything fails to resolve the current state needs to remain untouched.
+        // We also set up an inheritance chain for the locals here. This allows the view directive
+        // to quickly look up the correct definition for each view in the current state. Even
+        // though we create the locals object itself outside resolveState(), it is initially
+        // empty and gets filled asynchronously. We need to keep track of the promise for the
+        // (fully resolved) current locals, and pass this down the chain.
+        var resolved = $q.when(locals);
 
-      return transition;
+        for (var l = keep; l < toPath.length; l++, state = toPath[l]) {
+          locals = toLocals[l] = inherit(locals);
+          resolved = resolveState(state, toParams, state === to, resolved, locals, options);
+        }
+
+        // Once everything is resolved, we are ready to perform the actual transition
+        // and return a promise for the new state. We also keep track of what the
+        // current promise is, so that we can detect overlapping transitions and
+        // keep only the outcome of the last transition.
+        var transition = $state.transition = resolved.then(function () {
+          var l, entering, exiting;
+
+          if ($state.transition !== transition) return TransitionSuperseded;
+
+          // Exit 'from' states not kept
+          for (l = fromPath.length - 1; l >= keep; l--) {
+            exiting = fromPath[l];
+            if (exiting.self.onExit) {
+              $injector.invoke(exiting.self.onExit, exiting.self, exiting.locals.globals);
+            }
+            exiting.locals = null;
+          }
+
+          // Enter 'to' states not kept
+          for (l = keep; l < toPath.length; l++) {
+            entering = toPath[l];
+            entering.locals = toLocals[l];
+            if (entering.self.onEnter) {
+              $injector.invoke(entering.self.onEnter, entering.self, entering.locals.globals);
+            }
+          }
+
+          // Re-add the saved hash before we start returning things
+          if (hash) toParams['#'] = hash;
+
+          // Run it again, to catch any transitions in callbacks
+          if ($state.transition !== transition) return TransitionSuperseded;
+
+          // Update globals in $state
+          $state.$current = to;
+          $state.current = to.self;
+          $state.params = toParams;
+          copy($state.params, $stateParams);
+          $state.transition = null;
+
+          if (options.location && to.navigable) {
+            $urlRouter.push(to.navigable.url, to.navigable.locals.globals.$stateParams, {
+              $$avoidResync: true, replace: options.location === 'replace'
+            });
+          }
+
+          if (options.notify) {
+          /**
+           * @ngdoc event
+           * @name ui.router.state.$state#$stateChangeSuccess
+           * @eventOf ui.router.state.$state
+           * @eventType broadcast on root scope
+           * @description
+           * Fired once the state transition is **complete**.
+           *
+           * @param {Object} event Event object.
+           * @param {State} toState The state being transitioned to.
+           * @param {Object} toParams The params supplied to the `toState`.
+           * @param {State} fromState The current state, pre-transition.
+           * @param {Object} fromParams The params supplied to the `fromState`.
+           */
+            $rootScope.$broadcast('$stateChangeSuccess', to.self, toParams, from.self, fromParams);
+          }
+          $urlRouter.update(true);
+
+          return $state.current;
+        }, function (error) {
+          if ($state.transition !== transition) return TransitionSuperseded;
+
+          $state.transition = null;
+          /**
+           * @ngdoc event
+           * @name ui.router.state.$state#$stateChangeError
+           * @eventOf ui.router.state.$state
+           * @eventType broadcast on root scope
+           * @description
+           * Fired when an **error occurs** during transition. It's important to note that if you
+           * have any errors in your resolve functions (javascript errors, non-existent services, etc)
+           * they will not throw traditionally. You must listen for this $stateChangeError event to
+           * catch **ALL** errors.
+           *
+           * @param {Object} event Event object.
+           * @param {State} toState The state being transitioned to.
+           * @param {Object} toParams The params supplied to the `toState`.
+           * @param {State} fromState The current state, pre-transition.
+           * @param {Object} fromParams The params supplied to the `fromState`.
+           * @param {Error} error The resolve error object.
+           */
+          evt = $rootScope.$broadcast('$stateChangeError', to.self, toParams, from.self, fromParams, error);
+
+          if (!evt.defaultPrevented) {
+              $urlRouter.update();
+          }
+
+          return $q.reject(error);
+        });
+
+        return transition;
+      }
+
     };
 
     /**
@@ -1329,10 +1408,10 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
      *    first parameter, then the constructed href url will be built from the first navigable ancestor (aka
      *    ancestor with a valid url).
      * - **`inherit`** - {boolean=true}, If `true` will inherit url parameters from current url.
-     * - **`relative`** - {object=$state.$current}, When transitioning with relative path (e.g '^'), 
+     * - **`relative`** - {object=$state.$current}, When transitioning with relative path (e.g '^'),
      *    defines which state to be relative from.
      * - **`absolute`** - {boolean=false},  If true will generate an absolute url, e.g. "http://www.example.com/fullurl".
-     * 
+     *
      * @returns {string} compiled state url
      */
     $state.href = function href(stateOrName, params, options) {
@@ -1347,7 +1426,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
 
       if (!isDefined(state)) return null;
       if (options.inherit) params = inheritParams($stateParams, params || {}, $state.$current, state);
-      
+
       var nav = (state && options.lossy) ? state.navigable : state;
 
       if (!nav || nav.url === undefined || nav.url === null) {

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -215,6 +215,7 @@ describe('state', function () {
       $q.flush();
       expect($location.search()).toEqual({term: 'hello'});
       expect(called).toBeFalsy();
+
     }));
 
     it('updates $stateParams when state.reloadOnSearch=false, and only query params changed', inject(function ($state, $stateParams, $q, $location, $rootScope){
@@ -259,6 +260,70 @@ describe('state', function () {
       $state.transitionTo('A', { w00t: 'hi mom!' });
       $q.flush();
       expect($state.current).toBe(A);
+    }));
+
+    it('triggers $stateChangeValidation', inject(function ($state, $q, $rootScope) {
+      initStateTo(E, { i: 'iii' });
+      var called;
+      $rootScope.$on('$stateChangeValidation', function (ev, to, toParams, from, fromParams, registerValidator) {
+        expect(from).toBe(E);
+        expect(fromParams).toEqual({ i: 'iii' });
+        expect(to).toBe(D);
+        expect(toParams).toEqual({ x: '1', y: '2' });
+        expect(typeof registerValidator).toEqual('function');
+
+        expect($state.current).toBe(from); // $state not updated yet
+        expect($state.params).toEqual(fromParams);
+        called = true;
+      });
+      $state.transitionTo(D, { x: '1', y: '2' });
+      $q.flush();
+      expect(called).toBeTruthy();
+      expect($state.current).toBe(D);
+    }));
+
+    it('ignores truthy validators', inject(function ($state, $q, $rootScope) {
+        initStateTo(A);
+        var called;
+        $rootScope.$on('$stateChangeValidation', function (ev, to, toParams, from, fromParams, registerValidator) {
+          registerValidator({});
+          registerValidator($q.when(true));
+          called = true;
+        });
+        var promise = $state.transitionTo(B, {});
+        $q.flush();
+        expect(called).toBeTruthy();
+        expect($state.current).toBe(B);
+    }));
+
+    it('can be asynchronously cancelled by a falsy validator', inject(function ($state, $q, $rootScope) {
+        initStateTo(A);
+        var called;
+        $rootScope.$on('$stateChangeValidation', function (ev, to, toParams, from, fromParams, registerValidator) {
+          registerValidator(true);
+          registerValidator($q.when(null));
+          called = true;
+        });
+        var promise = $state.transitionTo(B, {});
+        $q.flush();
+        expect(called).toBeTruthy();
+        expect($state.current).toBe(A);
+        expect(resolvedError(promise)).toBeTruthy();
+    }));
+
+    it('ignores falsy validator when using preventDefault() in $stateChangeValidation', inject(function ($state, $q, $rootScope) {
+        initStateTo(A);
+        var called;
+        $rootScope.$on('$stateChangeValidation', function (ev, to, toParams, from, fromParams, registerValidator) {
+          ev.preventDefault();
+          registerValidator(false);
+          registerValidator($q.when(null));
+          called = true;
+        });
+        $state.transitionTo(B, {});
+        $q.flush();
+        expect(called).toBeTruthy();
+        expect($state.current).toBe(B);
     }));
 
     it('triggers $stateChangeStart', inject(function ($state, $q, $rootScope) {
@@ -764,7 +829,7 @@ describe('state', function () {
 
     it('should work for relative states', inject(function ($state, $q) {
       var options = { relative: $state.get('about') };
-      
+
       $state.transitionTo('about.person'); $q.flush();
       expect($state.is('.person', undefined, options)).toBe(true);
 
@@ -919,7 +984,7 @@ describe('state', function () {
       expect($state.href("root", {}, {inherit:false})).toEqual("#/root");
       expect($state.href("root", {}, {inherit:true})).toEqual("#/root?param1=1");
     }));
-    
+
     it('generates absolute url when absolute is true', inject(function ($state) {
       expect($state.href("about.sidebar", null, { absolute: true })).toEqual("http://server/#/about");
       locationProvider.html5Mode(true);


### PR DESCRIPTION
## Why?

> It [is] impossible to have asynchronous state validation without breaking the back history (so it doesn't work with angular-permission, for example).

([full comment](https://github.com/angular-ui/ui-router/issues/1525#issuecomment-87092724))

Until now, if we wanted to pause the state evaluation and resume it later, we had to do something like this :

```js
$rootScope.$on('$stateChangeStart', function (e) {
  e.preventDefault();
  doSomeLongRunningTask().then(function () {
    $state.go( 'foo' );
  });
});
```

However, it had a major drawback : it broke the backward navigation (because the preventDefault() / $state.go combo was rewriting the history, so that if you had a A->B->C history, then pressing the back button would bring you to B, then pressing it again would bring you to C instead of A).

## How?

This PR adds a $stateChangeValidation right before emitting the start event. At this point, listeners are still able to "hold" the transition execution by calling a function given to them as the last parameter of the event. Multiple listeners may hold the execution, and a single listener may also hold multiple time.

Each validator is a value, which may be a promise (in such case, we gently wait for it to be resolved). If at least one of the validator is falsy, the transition is cancelled. No more, no less.

The $stateChangeValidation event may be preventDefault()'d, to bypass any validation.

## Example

```js
$rootScope.$on('$stateChangeValidation',
function(event, toState, toParams, fromState, fromParams, registerValidator){
  registerValidator(soAsyncStore.get('userUid'));
  ...
})
```

## Backward Compatibility

This PR shouldn't break anything. If no listener ask for a hold on the transition, then the code will follow the current codepath, and everything will go as usual (we won't even wait for a dummy promise to resolve).

I've added tests which should prevent the feature from breaking in the future.

## Why not $locationChangeStart?

Because $locationChangeStart doesn't yet know what state will be navigated to. $stateChangeValidation knows, and can use this information to tune its permissions.
