### PR TITLE
fix(uiSrefActive): Apply active classes on lazy loaded states

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -239,13 +239,13 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate) {
       // Allow uiSref to communicate with uiSrefActive[Equals]
       this.$$addStateInfo = function (newState, newParams) {
         var state = $state.get(newState, stateContext($element));
-        if (state) {
-          states.push({
-            state: state,
-            params: newParams
-          });
-          update();
-        }
+
+        states.push({
+          state: state || { name: newState },
+          params: newParams
+        });
+
+        update();
       };
 
       $scope.$on('$stateChangeSuccess', update);

--- a/test/stateDirectivesSpec.js
+++ b/test/stateDirectivesSpec.js
@@ -392,11 +392,12 @@ describe('uiStateRef', function() {
 });
 
 describe('uiSrefActive', function() {
-    var el, template, scope, document;
+  var el, template, scope, document, _stateProvider;
 
   beforeEach(module('ui.router'));
 
   beforeEach(module(function($stateProvider) {
+    _stateProvider = $stateProvider;
     $stateProvider.state('top', {
       url: ''
     }).state('contacts', {
@@ -510,6 +511,42 @@ describe('uiSrefActive', function() {
     $state.transitionTo('contacts.item', { id: 2 });
     $q.flush();
     expect(angular.element(template[0]).attr('class')).toBe('ng-scope active');
+  }));
+
+  it('should match fuzzy on lazy loaded states', inject(function($rootScope, $q, $compile, $state) {
+    el = angular.element('<div><a ui-sref="contacts.lazy" ui-sref-active="active">Lazy Contact</a></div>');
+    template = $compile(el)($rootScope);
+    $rootScope.$digest();
+
+    $rootScope.$on('$stateNotFound', function () {
+      _stateProvider.state('contacts.lazy', {});
+    });
+
+    $state.transitionTo('contacts.item', { id: 1 });
+    $q.flush();
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
+
+    $state.transitionTo('contacts.lazy');
+    $q.flush();
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
+  }));
+
+  it('should match exactly on lazy loaded states', inject(function($rootScope, $q, $compile, $state) {
+    el = angular.element('<div><a ui-sref="contacts.lazy" ui-sref-active-eq="active">Lazy Contact</a></div>');
+    template = $compile(el)($rootScope);
+    $rootScope.$digest();
+
+    $rootScope.$on('$stateNotFound', function () {
+      _stateProvider.state('contacts.lazy', {});
+    });
+
+    $state.transitionTo('contacts.item', { id: 1 });
+    $q.flush();
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
+
+    $state.transitionTo('contacts.lazy');
+    $q.flush();
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
   }));
 });
 


### PR DESCRIPTION
#### Why? 
When generating new $state definitions through lazy loaded content, `uiSrefActive` will not reflect class changes on the associated anchor tag as the $state definition was not available in the initial stack. 

---

#### How? 
By pushing a *dummy* state definition to the initial stack of states found on application initialization with the `lazy: true` flag, class reflection onto the view is now working. However, this does not hold true (entirely) when launching your application **on** a lazy loaded state. 

Take the following structure: 

```js
$stateProvider.state('home', { url: '/' });
$stateProvider.state('home.lazy1', { url: '/l1' }); // State definition is added in a module loaded during runtime.
$stateProvider.state('home.lazy2', { url: '/l2' }); // State definition is added in a module loaded during runtime.
```

```html
<a ui-sref="home" ui-sref-active="active">Home</a>
<a ui-sref="home.lazy1" ui-sref-active="active">Lazy 1</a>
<a ui-sref="home.lazy2" ui-sref-active="active">Lazy 2</a>
```

If we were to launch the application at `localhost:9000/l1`, the `home.lazy1` anchor tag would get the `active` class applied to it. However, when navigating to `/l2`, `home.lazy2` would **not** get the `active` class applied to it. 

The same holds true for: 
* Launching on `/l2` and navigating to `/l1`. 
* Launching on `/` and navigating to either of the lazy loaded states.

---

[jsBin w/fix (see the bottom)](http://jsbin.com/fememinina/5/edit?html,js,output)
[gist of possible setup](https://gist.github.com/kasperlewau/4b3afa5587a55ccd7481)

My first PR to ui-router, feel free to dissect the commit/PR, here's hoping you won't have too much to do!

Fixes #915 