### PR TITLE
feat(uiView): support set scroll to top before transition

### DIFF
--- a/src/viewDirective.js
+++ b/src/viewDirective.js
@@ -26,6 +26,9 @@
  * functionality, call `$uiViewScrollProvider.useAnchorScroll()`.*
  *
  * @param {string=} onload Expression to evaluate whenever the view updates.
+ *
+ * @param {string=} resetscroll It allows you to reset the window scroll to 
+ * the top before transitioning to a new state.
  * 
  * @example
  * A view can be unnamed or named. 
@@ -110,9 +113,24 @@
  * <ui-view autoscroll='false'/>
  * <ui-view autoscroll='scopeVariable'/>
  * </pre>
+ *
+ * Examples for `resetscroll`:
+ *
+ * <pre>
+ * <!-- If resetscroll present with no expression,
+ *      then reset window scroll to top before transition -->
+ * <ui-view resetscroll/>
+ *
+ * <!-- If resetscroll present with valid expression,
+ *      then reset window scroll to top before transition if expression 
+ *      evaluates to true -->
+ * <ui-view resetscroll='true'/>
+ * <ui-view resetscroll='false'/>
+ * <ui-view resetscroll='scopeVariable'/>
+ * </pre>
  */
-$ViewDirective.$inject = ['$state', '$injector', '$uiViewScroll', '$interpolate'];
-function $ViewDirective(   $state,   $injector,   $uiViewScroll,   $interpolate) {
+$ViewDirective.$inject = ['$state', '$injector', '$uiViewScroll', '$interpolate', '$window'];
+function $ViewDirective(   $state,   $injector,   $uiViewScroll,   $interpolate, $window) {
 
   function getService() {
     return ($injector.has) ? function(service) {
@@ -173,9 +191,10 @@ function $ViewDirective(   $state,   $injector,   $uiViewScroll,   $interpolate)
     compile: function (tElement, tAttrs, $transclude) {
       return function (scope, $element, attrs) {
         var previousEl, currentEl, currentScope, latestLocals,
-            onloadExp     = attrs.onload || '',
-            autoScrollExp = attrs.autoscroll,
-            renderer      = getRenderer(attrs, scope);
+            onloadExp       = attrs.onload || '',
+            autoScrollExp   = attrs.autoscroll,
+            resetScrollExp  = attrs.resetscroll,
+            renderer        = getRenderer(attrs, scope);
 
         scope.$on('$stateChangeSuccess', function() {
           updateView(false);
@@ -204,6 +223,10 @@ function $ViewDirective(   $state,   $injector,   $uiViewScroll,   $interpolate)
 
             previousEl = currentEl;
             currentEl = null;
+          }
+
+          if (angular.isDefined(resetScrollExp) && !resetScrollExp || scope.$eval(resetScrollExp)) {
+            $window.scrollTo(0, 0);
           }
         }
 

--- a/test/viewDirectiveSpec.js
+++ b/test/viewDirectiveSpec.js
@@ -114,10 +114,12 @@ describe('uiView', function () {
       .state('l', lState)
   }));
 
-  beforeEach(inject(function ($rootScope, _$compile_) {
+  beforeEach(inject(function ($rootScope, _$compile_, _$window_) {
     scope = $rootScope.$new();
     $compile = _$compile_;
     elem = angular.element('<div>');
+
+    spyOn(_$window_, 'scrollTo');
   }));
 
   describe('linking ui-directive', function () {
@@ -295,6 +297,42 @@ describe('uiView', function () {
       }
 
       expect($uiViewScroll).toHaveBeenCalledWith(target);
+    }));
+  });
+
+  describe('resetscroll attribute', function () {
+    it('should NOT resetscroll when unspecified', inject(function ($state, $q, $window, $animate) {
+      elem.append($compile('<div><ui-view></ui-view></div>')(scope));
+
+      $state.transitionTo(aState);
+      $q.flush();
+
+      expect($window.scrollTo).not.toHaveBeenCalled();
+    }));
+
+    it('should resetscroll when expression is missing', inject(function ($state, $q, $window, $animate) {
+      elem.append($compile('<div><ui-view resetscroll></ui-view></div>')(scope));
+      $state.transitionTo(aState);
+      $q.flush();
+
+      expect($window.scrollTo).toHaveBeenCalledWith(0, 0);
+    }));
+
+    it('should resetscroll based on expression', inject(function ($state, $q, $window, $animate) {
+      scope.doScroll = false;
+
+      elem.append($compile('<div><ui-view resetscroll="doScroll"></ui-view></div>')(scope));
+
+      $state.transitionTo(aState);
+      $q.flush();
+
+      expect($window.scrollTo).not.toHaveBeenCalled();
+
+      scope.doScroll = true;
+      $state.transitionTo(bState);
+      $q.flush();
+
+      expect($window.scrollTo).toHaveBeenCalledWith(0, 0);
     }));
   });
 


### PR DESCRIPTION
Allow setting `resetscroll` as an attribute of `uiView` to
set the scrollTo of the window to 0 0 before transitioning
to a new state. Before the window was not reset and the
scroll on the new state would be the scroll of the previous
state.
