### PR TITLE
feat(isState): add support for `params` and `options` for `isState` filter

### DIFF
--- a/src/stateFilters.js
+++ b/src/stateFilters.js
@@ -2,15 +2,26 @@
  * @ngdoc filter
  * @name ui.router.state.filter:isState
  *
+ * @param {string|object} stateOrName The state name (absolute or relative) or state object you'd like to check.
+ * @param {Object} onbject config represent the optional arguments
+ * of @link ui.router.state.$state#methods_is $state.is("stateName"[, params [, options]])}. Valid keys are:
+ *     - `params`: {object=} params A param object, e.g. `{sectionId: section.id}`, that you'd like
+ *                 to test against the current active state.
+ *     - `options`: {object=} options An options object.  The options are:
+ *                 - **`relative`** - {string|object} -  If `stateOrName` is a relative state name and `options.relative` is set, it will
+ *                  test relative to `options.relative` state (or name).
+ * @returns {boolean} Returns true if it is the state.
+ *
  * @requires ui.router.state.$state
  *
  * @description
- * Translates to {@link ui.router.state.$state#methods_is $state.is("stateName")}.
+ * Translates to {@link ui.router.state.$state#methods_is $state.is("stateName"[, params [, options]])}.
  */
 $IsStateFilter.$inject = ['$state'];
 function $IsStateFilter($state) {
-  var isFilter = function (state) {
-    return $state.is(state);
+  var isFilter = function (state, stateOptions) {
+    stateOptions = stateOptions || {};
+    return $state.is(state, stateOptions.params, stateOptions.options);
   };
   isFilter.$stateful = true;
   return isFilter;

--- a/test/stateFiltersSpec.js
+++ b/test/stateFiltersSpec.js
@@ -3,7 +3,10 @@ describe('isState filter', function() {
   beforeEach(module(function($stateProvider) {
     $stateProvider
       .state('a', { url: '/' })
-      .state('a.b', { url: '/b' });
+      .state('a.b', { url: '/b' })
+      .state('a.c', { url: '/:x?y' })
+      .state('d', { url: '/' })
+      .state('d.c', { url: '/c' });
   }));
 
   it('should return true if the current state exactly matches the input state', inject(function($parse, $state, $q, $rootScope) {
@@ -16,6 +19,34 @@ describe('isState filter', function() {
     $state.go('a.b');
     $q.flush();
     expect($parse('"a" | isState')($rootScope)).toBe(false);
+  }));
+
+  it('should return true when the current state is passed with matching parameters', inject(function ($parse, $q, $state, $rootScope) {
+    $state.go('a.c', {x: 'foo', y: 'bar'});
+    $q.flush();
+    expect($parse('"a.c" | isState')($rootScope)).toBe(true);
+    expect($parse('"a.c" | isState:{params:{x: "foo", y: "bar"}}')($rootScope)).toBe(true);
+    expect($parse('"a.c" | isState:{params:{x: "bar", y: "foo"}}')($rootScope)).toBe(false);
+    expect($parse('"a.c" | isState:{params:{x: "bar"}}')($rootScope)).toBe(false);
+    expect($parse('"a.c" | isState:{params:{y: "foo"}}')($rootScope)).toBe(false);
+    expect($parse('"a.c" | isState:{params:{x: "bar", y: "foo", z: "hello"}}')($rootScope)).toBe(false);
+  }));
+
+  it('should work for relative states', inject(function ($parse, $q, $state, $rootScope) {
+    var scope = $rootScope.$new();
+    scope.options = { relative: $state.get('a') };
+
+    $state.go('a.c');
+    $q.flush();
+
+    expect($parse('".c" | isState:{options: options}')(scope)).toBe(true);
+
+    $state.go('a.c', {x: 'foo', y: 'bar'});
+    $q.flush();
+    expect($parse('".c" | isState:{params:{x: "foo", y: "bar"}, options: options}')(scope)).toBe(true);
+
+    scope.options.relative = $state.get('d');
+    expect($parse('".c" | isState:{options: options}')(scope)).toBe(false);
   }));
 });
 


### PR DESCRIPTION
Add support for `params` and `options` optional arguments for `isState`
filter in order to have the same functionality as `$state.is(stateName,
params, options)`.
e.g.:
- `'a.c' | isState:{params: {x: 'foo', y: 'bar'}}` in the case of
  `$stateProvider.state('a.c', { url: '/:x?y' })`
- `'.c' | isState:{params: {x: 'foo', y: 'bar'}, options: options}` with `$scope.options =
  { relative: $state.get('a') }` in the case of
  `$stateProvider.state('a.c', { url: '/:x?y' })`
