### PR TITLE
refactor(commonjs): Added support for commonjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+require('./release/angular-ui-router.js');
+module.exports = 'ui.router';
+

--- a/package.json
+++ b/package.json
@@ -62,5 +62,5 @@
     "grunt-conventional-changelog": "~1.1.0",
     "grunt-ngdocs": "~0.2.5"
   },
-  "main": "release/angular-ui-router.js"
+  "main": "index.js"
 }


### PR DESCRIPTION
Added `ui.router` to module exports so that after installing via npm, the package can be required in the angular module dependency list such as:

```angular.module('myApp', [require('angular-ui-router')]);```

This is helpful for Browserify and Webpack.