### PR TITLE
fix(common.js): Error if parents[i] is undefined

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -96,7 +96,7 @@ function inheritParams(currentParams, newParams, $current, $to) {
   var parents = ancestors($current, $to), parentParams, inherited = {}, inheritList = [];
 
   for (var i in parents) {
-    if (!parents[i].params) continue;
+    if (!parents[i] || !parents[i].params) continue;
     parentParams = objectKeys(parents[i].params);
     if (!parentParams.length) continue;
 


### PR DESCRIPTION
hasOwnProperty still would throw an error if parents[i] was undefined.