### PR TITLE
fix($state): Fixed bug within resolveState() method

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -1405,7 +1405,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
             return $view.load(name, { view: view, locals: dst.globals, params: $stateParams, notify: options.notify }) || '';
           }];
 
-          viewsPromises.push($resolve.resolve(injectables, dst.globals, dst.resolve, state).then(function (result) {
+          viewsPromises.push($resolve.resolve(injectables, locals, dst.resolve, state).then(function (result) {
             // References to the controller (only instantiated at link time)
             if (isFunction(view.controllerProvider) || isArray(view.controllerProvider)) {
               var injectLocals = angular.extend({}, injectables, dst.globals);


### PR DESCRIPTION
Change the second parameter of $resolve.resolve in line 3788 from `dst.globals` to `locals` to make resolving work as expected.

Additional information: Commit afa20f22 changed the resolveState() method. It broke resolving promises, so they were not injected to the controller. I got the following error:

```
Error: [$injector:unpr] Unknown provider: assetProvider <- asset <- VisualizationOverviewCtrl
[...]
```
