### PR TITLE
feat(uiSrefActive): allow active & active-eq on same element

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -228,7 +228,7 @@ $StateRefActiveDirective.$inject = ['$state', '$stateParams', '$interpolate'];
 function $StateRefActiveDirective($state, $stateParams, $interpolate) {
   return  {
     restrict: "A",
-    controller: ['$scope', '$element', '$attrs', function ($scope, $element, $attrs) {
+    controller: ['$scope', '$element', '$attrs', '$timeout', function ($scope, $element, $attrs, $timeout) {
       var states = [], activeClass, activeEqClass;
 
       // There probably isn't much point in $observing this
@@ -253,22 +253,24 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate) {
 
       // Update route state
       function update() {
-        if (states.length) {
-          for (var i = 0; i < states.length; i++) {
-            if (anyMatch(states[i].state, states[i].params)) {
-              $element.addClass(activeClass);
-            } else {
-              $element.removeClass(activeClass);
-            }
+        for (var i = 0; i < states.length; i++) {
+          if (anyMatch(states[i].state, states[i].params)) {
+            addClass($element, activeClass);
+          } else {
+            removeClass($element, activeClass);
+          }
 
-            if (exactMatch(states[i].state, states[i].params)) {
-              $element.addClass(activeEqClass);
-            } else {
-              $element.removeClass(activeEqClass);
-            }
-          }          
+          if (exactMatch(states[i].state, states[i].params)) {
+            addClass($element, activeEqClass);
+          } else {
+            removeClass($element, activeEqClass);
+          }
         }
       }
+
+      function addClass(el, className) { $timeout(function() { el.addClass(className); }); }
+
+      function removeClass(el, className) { el.removeClass(className); }
 
       function anyMatch(state, params) { return $state.includes(state.name, params); }
 

--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -229,12 +229,13 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate) {
   return  {
     restrict: "A",
     controller: ['$scope', '$element', '$attrs', function ($scope, $element, $attrs) {
-      var states = [], activeClass;
+      var states = [], activeClass, activeEqClass;
 
       // There probably isn't much point in $observing this
       // uiSrefActive and uiSrefActiveEq share the same directive object with some
       // slight difference in logic routing
-      activeClass = $interpolate($attrs.uiSrefActiveEq || $attrs.uiSrefActive || '', false)($scope);
+      activeClass = $interpolate($attrs.uiSrefActive || '', false)($scope);
+      activeEqClass = $interpolate($attrs.uiSrefActiveEq || '', false)($scope);
 
       // Allow uiSref to communicate with uiSrefActive[Equals]
       this.$$addStateInfo = function (newState, newParams) {
@@ -252,29 +253,27 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate) {
 
       // Update route state
       function update() {
-        if (anyMatch()) {
-          $element.addClass(activeClass);
-        } else {
-          $element.removeClass(activeClass);
+        if (states.length) {
+          for (var i = 0; i < states.length; i++) {
+            if (anyMatch(states[i].state, states[i].params)) {
+              $element.addClass(activeClass);
+            } else {
+              $element.removeClass(activeClass);
+            }
+
+            if (exactMatch(states[i].state, states[i].params)) {
+              $element.addClass(activeEqClass);
+            } else {
+              $element.removeClass(activeEqClass);
+            }
+          }          
         }
       }
 
-      function anyMatch() {
-        for (var i = 0; i < states.length; i++) {
-          if (isMatch(states[i].state, states[i].params)) {
-            return true;
-          }
-        }
-        return false;
-      }
+      function anyMatch(state, params) { return $state.includes(state.name, params); }
 
-      function isMatch(state, params) {
-        if (typeof $attrs.uiSrefActiveEq !== 'undefined') {
-          return $state.is(state.name, params);
-        } else {
-          return $state.includes(state.name, params);
-        }
-      }
+      function exactMatch(state, params) { return $state.is(state.name, params); }
+
     }]
   };
 }

--- a/test/stateDirectivesSpec.js
+++ b/test/stateDirectivesSpec.js
@@ -420,100 +420,113 @@ describe('uiSrefActive', function() {
     document = $document[0];
   }));
 
-  it('should update class for sibling uiSref', inject(function($rootScope, $q, $compile, $state) {
+  it('should update class for sibling uiSref', inject(function($rootScope, $q, $compile, $state, $timeout) {
     el = angular.element('<div><a ui-sref="contacts.item({ id: 1 })" ui-sref-active="active">Contacts</a><a ui-sref="contacts.item({ id: 2 })" ui-sref-active="active">Contacts</a></div>');
     template = $compile(el)($rootScope);
     $rootScope.$digest();
 
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
     $state.transitionTo('contacts.item', { id: 1 });
+    $timeout.flush();
     $q.flush();
 
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
 
     $state.transitionTo('contacts.item', { id: 2 });
+    $timeout.flush();
     $q.flush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
   }));
 
-  it('should match state\'s parameters', inject(function($rootScope, $q, $compile, $state) {
+  it('should match state\'s parameters', inject(function($rootScope, $q, $compile, $state, $timeout) {
     el = angular.element('<div><a ui-sref="contacts.item.detail({ foo: \'bar\' })" ui-sref-active="active">Contacts</a></div>');
     template = $compile(el)($rootScope);
     $rootScope.$digest();
 
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
     $state.transitionTo('contacts.item.detail', { id: 5, foo: 'bar' });
+    $timeout.flush();
     $q.flush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
 
     $state.transitionTo('contacts.item.detail', { id: 5, foo: 'baz' });
+    $timeout.flush();
     $q.flush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
   }));
 
-  it('should match on child states', inject(function($rootScope, $q, $compile, $state) {
+  it('should match on child states', inject(function($rootScope, $q, $compile, $state, $timeout) {
     template = $compile('<div><a ui-sref="contacts.item({ id: 1 })" ui-sref-active="active">Contacts</a></div>')($rootScope);
     $rootScope.$digest();
     var a = angular.element(template[0].getElementsByTagName('a')[0]);
 
     $state.transitionTo('contacts.item.edit', { id: 1 });
+    $timeout.flush();
     $q.flush();
     expect(a.attr('class')).toMatch(/active/);
 
     $state.transitionTo('contacts.item.edit', { id: 4 });
+    $timeout.flush();
     $q.flush();
     expect(a.attr('class')).not.toMatch(/active/);
   }));
 
-  it('should NOT match on child states when active-equals is used', inject(function($rootScope, $q, $compile, $state) {
+  it('should NOT match on child states when active-equals is used', inject(function($rootScope, $q, $compile, $state, $timeout) {
     template = $compile('<div><a ui-sref="contacts.item({ id: 1 })" ui-sref-active-eq="active">Contacts</a></div>')($rootScope);
     $rootScope.$digest();
     var a = angular.element(template[0].getElementsByTagName('a')[0]);
 
     $state.transitionTo('contacts.item', { id: 1 });
+    $timeout.flush();
     $q.flush();
     expect(a.attr('class')).toMatch(/active/);
 
     $state.transitionTo('contacts.item.edit', { id: 1 });
+    $timeout.flush();
     $q.flush();
     expect(a.attr('class')).not.toMatch(/active/);
   }));
 
-  it('should match on child states when active-equals and active-equals-eq is used', inject(function($rootScope, $q, $compile, $state) {
+  it('should match on child states when active-equals and active-equals-eq is used', inject(function($rootScope, $q, $compile, $state, $timeout) {
     template = $compile('<div><a ui-sref="contacts.item({ id: 1 })" ui-sref-active="active" ui-sref-active-eq="active-eq">Contacts</a></div>')($rootScope);
     $rootScope.$digest();
     var a = angular.element(template[0].getElementsByTagName('a')[0]);
 
     $state.transitionTo('contacts.item', { id: 1 });
+    $timeout.flush();
     $q.flush();
     expect(a.attr('class')).toMatch(/active/);
     expect(a.attr('class')).toMatch(/active-eq/);
 
     $state.transitionTo('contacts.item.edit', { id: 1 });
+    $timeout.flush();
     $q.flush();
     expect(a.attr('class')).toMatch(/active/);
     expect(a.attr('class')).not.toMatch(/active-eq/);
   }));
 
-  it('should resolve relative state refs', inject(function($rootScope, $q, $compile, $state) {
+  it('should resolve relative state refs', inject(function($rootScope, $q, $compile, $state, $timeout) {
     el = angular.element('<section><div ui-view></div></section>');
     template = $compile(el)($rootScope);
     $rootScope.$digest();
 
     $state.transitionTo('contacts');
+    $timeout.flush();
     $q.flush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope');
 
     $state.transitionTo('contacts.item', { id: 6 });
+    $timeout.flush();
     $q.flush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope active');
 
     $state.transitionTo('contacts.item', { id: 5 });
+    $timeout.flush();
     $q.flush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope');
   }));
 
-  it('should match on any child state refs', inject(function($rootScope, $q, $compile, $state) {
+  it('should match on any child state refs', inject(function($rootScope, $q, $compile, $state, $timeout) {
     el = angular.element('<div ui-sref-active="active"><a ui-sref="contacts.item({ id: 1 })">Contacts</a><a ui-sref="contacts.item({ id: 2 })">Contacts</a></div>');
     template = $compile(el)($rootScope);
     $rootScope.$digest();
@@ -521,15 +534,17 @@ describe('uiSrefActive', function() {
     expect(angular.element(template[0]).attr('class')).toBe('ng-scope');
 
     $state.transitionTo('contacts.item', { id: 1 });
+    $timeout.flush();
     $q.flush();
     expect(angular.element(template[0]).attr('class')).toBe('ng-scope active');
 
     $state.transitionTo('contacts.item', { id: 2 });
+    $timeout.flush();
     $q.flush();
     expect(angular.element(template[0]).attr('class')).toBe('ng-scope active');
   }));
 
-  it('should match fuzzy on lazy loaded states', inject(function($rootScope, $q, $compile, $state) {
+  it('should match fuzzy on lazy loaded states', inject(function($rootScope, $q, $compile, $state, $timeout) {
     el = angular.element('<div><a ui-sref="contacts.lazy" ui-sref-active="active">Lazy Contact</a></div>');
     template = $compile(el)($rootScope);
     $rootScope.$digest();
@@ -539,15 +554,17 @@ describe('uiSrefActive', function() {
     });
 
     $state.transitionTo('contacts.item', { id: 1 });
+    $timeout.flush();
     $q.flush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
 
     $state.transitionTo('contacts.lazy');
+    $timeout.flush();
     $q.flush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
   }));
 
-  it('should match exactly on lazy loaded states', inject(function($rootScope, $q, $compile, $state) {
+  it('should match exactly on lazy loaded states', inject(function($rootScope, $q, $compile, $state, $timeout) {
     el = angular.element('<div><a ui-sref="contacts.lazy" ui-sref-active-eq="active">Lazy Contact</a></div>');
     template = $compile(el)($rootScope);
     $rootScope.$digest();
@@ -557,10 +574,12 @@ describe('uiSrefActive', function() {
     });
 
     $state.transitionTo('contacts.item', { id: 1 });
+    $timeout.flush();
     $q.flush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
 
     $state.transitionTo('contacts.lazy');
+    $timeout.flush();
     $q.flush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
   }));

--- a/test/stateDirectivesSpec.js
+++ b/test/stateDirectivesSpec.js
@@ -479,6 +479,22 @@ describe('uiSrefActive', function() {
     expect(a.attr('class')).not.toMatch(/active/);
   }));
 
+  it('should match on child states when active-equals and active-equals-eq is used', inject(function($rootScope, $q, $compile, $state) {
+    template = $compile('<div><a ui-sref="contacts.item({ id: 1 })" ui-sref-active="active" ui-sref-active-eq="active-eq">Contacts</a></div>')($rootScope);
+    $rootScope.$digest();
+    var a = angular.element(template[0].getElementsByTagName('a')[0]);
+
+    $state.transitionTo('contacts.item', { id: 1 });
+    $q.flush();
+    expect(a.attr('class')).toMatch(/active/);
+    expect(a.attr('class')).toMatch(/active-eq/);
+
+    $state.transitionTo('contacts.item.edit', { id: 1 });
+    $q.flush();
+    expect(a.attr('class')).toMatch(/active/);
+    expect(a.attr('class')).not.toMatch(/active-eq/);
+  }));
+
   it('should resolve relative state refs', inject(function($rootScope, $q, $compile, $state) {
     el = angular.element('<section><div ui-view></div></section>');
     template = $compile(el)($rootScope);


### PR DESCRIPTION
This pull request will allow the usage of both `ui-sref-active` and `ui-sref-active-eq` on the same element. 

One use case includes menus with expanding states where a parent element can be both `active` and `open`, such as in this example:

```html
<ul>
  <li ui-sref-active="open" ui-sref-active-eq="active">
    <a ui-sref="home"></a>
    <ul>
      <li ui-sref-active-eq="active">
        <a ui-sref="home.view1"></a>
      </li>
      <li ui-sref-active-eq="active">
        <a ui-sref="home.view2"></a>
      </li>
    </ul>
  </li>
  <li ui-sref-active="open" ui-sref-active-eq="active">
    <a ui-sref="account"></a>
    <ul>
      <li ui-sref-active-eq="active">
        <a ui-sref="account.view1"></a>
      </li>
      <li ui-sref-active-eq="active">
        <a ui-sref="account.view2"></a>
      </li>
      <li ui-sref-active-eq="active">
        <a ui-sref="account.view3"></a>
      </li>
    </ul>
  </li>
</ul>
```

When the account child views are active, the parent view should have a class of "open". However, when the parent is active, then the parent element should have both "open" and "active" classes.

This pull request exposes a race condition bug which I have created a separate issue for, #1997. Due to the slight decrease in performance by adding this functionality, the bug is now evident through the failure of one unit test.