### PR TITLE
fix(urlMatcherFactory): Slashes are now properly decoded in url params

### DIFF
--- a/src/urlMatcherFactory.js
+++ b/src/urlMatcherFactory.js
@@ -579,6 +579,9 @@ function $UrlMatcherFactory() {
       // TODO: in 1.0, make string .is() return false if value is undefined/null by default.
       // In 0.2.x, string params are optional by default for backwards compat
       is: function(val) { return val == null || !isDefined(val) || typeof val === "string"; },
+      $normalize: function(val){
+        return this.decode(val);
+      },
       pattern: /[^/]*/
     },
     int: {

--- a/test/urlMatcherFactorySpec.js
+++ b/test/urlMatcherFactorySpec.js
@@ -65,6 +65,8 @@ describe("UrlMatcher", function () {
     var matcher = new UrlMatcher('/:foo');
     expect(matcher.format({ foo: "/" })).toBe('/%252F');
     expect(matcher.format({ foo: "//" })).toBe('/%252F%252F');
+    expect(matcher.exec('/%2F').foo).toBe('/');
+    expect(matcher.exec('/%2F%2F').foo).toBe('//');
   });
 
   describe("snake-case parameters", function() {


### PR DESCRIPTION

Fixes: #1973, #1645