### PR TITLE
feat(uiSrefActive): allow active & active-eq on same element

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -228,13 +228,14 @@ $StateRefActiveDirective.$inject = ['$state', '$stateParams', '$interpolate'];
 function $StateRefActiveDirective($state, $stateParams, $interpolate) {
   return  {
     restrict: "A",
-    controller: ['$scope', '$element', '$attrs', function ($scope, $element, $attrs) {
-      var states = [], activeClass;
+    controller: ['$scope', '$element', '$attrs', '$timeout', function ($scope, $element, $attrs, $timeout) {
+      var states = [], activeClass, activeEqClass;
 
       // There probably isn't much point in $observing this
       // uiSrefActive and uiSrefActiveEq share the same directive object with some
       // slight difference in logic routing
-      activeClass = $interpolate($attrs.uiSrefActiveEq || $attrs.uiSrefActive || '', false)($scope);
+      activeClass = $interpolate($attrs.uiSrefActive || '', false)($scope);
+      activeEqClass = $interpolate($attrs.uiSrefActiveEq || '', false)($scope);
 
       // Allow uiSref to communicate with uiSrefActive[Equals]
       this.$$addStateInfo = function (newState, newParams) {
@@ -252,29 +253,29 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate) {
 
       // Update route state
       function update() {
-        if (anyMatch()) {
-          $element.addClass(activeClass);
-        } else {
-          $element.removeClass(activeClass);
-        }
-      }
-
-      function anyMatch() {
         for (var i = 0; i < states.length; i++) {
-          if (isMatch(states[i].state, states[i].params)) {
-            return true;
+          if (anyMatch(states[i].state, states[i].params)) {
+            addClass($element, activeClass);
+          } else {
+            removeClass($element, activeClass);
+          }
+
+          if (exactMatch(states[i].state, states[i].params)) {
+            addClass($element, activeEqClass);
+          } else {
+            removeClass($element, activeEqClass);
           }
         }
-        return false;
       }
 
-      function isMatch(state, params) {
-        if (typeof $attrs.uiSrefActiveEq !== 'undefined') {
-          return $state.is(state.name, params);
-        } else {
-          return $state.includes(state.name, params);
-        }
-      }
+      function addClass(el, className) { $timeout(function () { el.addClass(className); }); }
+
+      function removeClass(el, className) { el.removeClass(className); }
+
+      function anyMatch(state, params) { return $state.includes(state.name, params); }
+
+      function exactMatch(state, params) { return $state.is(state.name, params); }
+
     }]
   };
 }

--- a/test/stateDirectivesSpec.js
+++ b/test/stateDirectivesSpec.js
@@ -416,8 +416,16 @@ describe('uiSrefActive', function() {
     });
   }));
 
-  beforeEach(inject(function($document) {
+  beforeEach(inject(function($document, $timeout) {
     document = $document[0];
+    timeoutFlush = function () {
+      try {
+        $timeout.flush();
+      } catch (e) {
+        // Angular 1.0.8 throws 'No deferred tasks to be flushed' if there is nothing in queue.
+        // Behave as Angular >=1.1.5 and do nothing in such case.
+      }
+    }
   }));
 
   it('should update class for sibling uiSref', inject(function($rootScope, $q, $compile, $state) {
@@ -428,11 +436,12 @@ describe('uiSrefActive', function() {
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
     $state.transitionTo('contacts.item', { id: 1 });
     $q.flush();
-
+    timeoutFlush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
 
     $state.transitionTo('contacts.item', { id: 2 });
     $q.flush();
+    timeoutFlush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
   }));
 
@@ -444,10 +453,12 @@ describe('uiSrefActive', function() {
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
     $state.transitionTo('contacts.item.detail', { id: 5, foo: 'bar' });
     $q.flush();
+    timeoutFlush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
 
     $state.transitionTo('contacts.item.detail', { id: 5, foo: 'baz' });
     $q.flush();
+    timeoutFlush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
   }));
 
@@ -458,10 +469,12 @@ describe('uiSrefActive', function() {
 
     $state.transitionTo('contacts.item.edit', { id: 1 });
     $q.flush();
+    timeoutFlush();
     expect(a.attr('class')).toMatch(/active/);
 
     $state.transitionTo('contacts.item.edit', { id: 4 });
     $q.flush();
+    timeoutFlush();
     expect(a.attr('class')).not.toMatch(/active/);
   }));
 
@@ -472,11 +485,31 @@ describe('uiSrefActive', function() {
 
     $state.transitionTo('contacts.item', { id: 1 });
     $q.flush();
+    timeoutFlush();
     expect(a.attr('class')).toMatch(/active/);
 
     $state.transitionTo('contacts.item.edit', { id: 1 });
     $q.flush();
+    timeoutFlush();
     expect(a.attr('class')).not.toMatch(/active/);
+  }));
+
+  it('should match on child states when active-equals and active-equals-eq is used', inject(function($rootScope, $q, $compile, $state, $timeout) {
+    template = $compile('<div><a ui-sref="contacts.item({ id: 1 })" ui-sref-active="active" ui-sref-active-eq="active-eq">Contacts</a></div>')($rootScope);
+    $rootScope.$digest();
+    var a = angular.element(template[0].getElementsByTagName('a')[0]);
+
+    $state.transitionTo('contacts.item', { id: 1 });
+    $q.flush();
+    timeoutFlush();
+    expect(a.attr('class')).toMatch(/active/);
+    expect(a.attr('class')).toMatch(/active-eq/);
+
+    $state.transitionTo('contacts.item.edit', { id: 1 });
+    $q.flush();
+    timeoutFlush();
+    expect(a.attr('class')).toMatch(/active/);
+    expect(a.attr('class')).not.toMatch(/active-eq/);
   }));
 
   it('should resolve relative state refs', inject(function($rootScope, $q, $compile, $state) {
@@ -486,14 +519,17 @@ describe('uiSrefActive', function() {
 
     $state.transitionTo('contacts');
     $q.flush();
+    timeoutFlush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope');
 
     $state.transitionTo('contacts.item', { id: 6 });
     $q.flush();
+    timeoutFlush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope active');
 
     $state.transitionTo('contacts.item', { id: 5 });
     $q.flush();
+    timeoutFlush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('ng-scope');
   }));
 
@@ -506,10 +542,12 @@ describe('uiSrefActive', function() {
 
     $state.transitionTo('contacts.item', { id: 1 });
     $q.flush();
+    timeoutFlush();
     expect(angular.element(template[0]).attr('class')).toBe('ng-scope active');
 
     $state.transitionTo('contacts.item', { id: 2 });
     $q.flush();
+    timeoutFlush();
     expect(angular.element(template[0]).attr('class')).toBe('ng-scope active');
   }));
 
@@ -524,10 +562,12 @@ describe('uiSrefActive', function() {
 
     $state.transitionTo('contacts.item', { id: 1 });
     $q.flush();
+    timeoutFlush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
 
     $state.transitionTo('contacts.lazy');
     $q.flush();
+    timeoutFlush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
   }));
 
@@ -542,10 +582,12 @@ describe('uiSrefActive', function() {
 
     $state.transitionTo('contacts.item', { id: 1 });
     $q.flush();
+    timeoutFlush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
 
     $state.transitionTo('contacts.lazy');
     $q.flush();
+    timeoutFlush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
   }));
 });


### PR DESCRIPTION
This pull request will allow the usage of both `ui-sref-active` and `ui-sref-active-eq` on the same element. 

One use case includes menus with expanding states where a parent element can be both `active` and `open`, such as in this example:

```html
<ul>
  <li ui-sref-active="open" ui-sref-active-eq="active">
    <a ui-sref="home"></a>
    <ul>
      <li ui-sref-active-eq="active">
        <a ui-sref="home.view1"></a>
      </li>
      <li ui-sref-active-eq="active">
        <a ui-sref="home.view2"></a>
      </li>
    </ul>
  </li>
  <li ui-sref-active="open" ui-sref-active-eq="active">
    <a ui-sref="account"></a>
    <ul>
      <li ui-sref-active-eq="active">
        <a ui-sref="account.view1"></a>
      </li>
      <li ui-sref-active-eq="active">
        <a ui-sref="account.view2"></a>
      </li>
      <li ui-sref-active-eq="active">
        <a ui-sref="account.view3"></a>
      </li>
    </ul>
  </li>
</ul>
```

When the account child views are active, the parent view should have a class of "open". However, when the parent is active, then the parent element should have both "open" and "active" classes.

This pull request exposes and squashes a race condition bug that's present today, #1997.

I apologize that this is a duplicate of a pull request I previously closed. I trashed that request due to failing tests before learning the quirks of `$timeout.flush()` in Karma. After digging around, I noticed that you had a comment explaining a workaround. Reopened after getting all the tests sorted out and passing.