### PR TITLE
feat(improved commonjs and es6 ready) Update library to export main module through CommonJS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,12 +21,12 @@ module.exports = function (grunt) {
     concat: {
       options: {
         banner: '<%= meta.banner %>\n\n'+
+                '(function (window, angular, undefined) {\n',
+        footer: '})(window, window.angular);'+ 
                 '/* commonjs package manager support (eg componentjs) */\n'+
                 'if (typeof module !== "undefined" && typeof exports !== "undefined" && module.exports === exports){\n'+
-                '  module.exports = \'ui.router\';\n'+
-                '}\n\n'+
-                '(function (window, angular, undefined) {\n',
-        footer: '})(window, window.angular);'
+                '  module.exports = angular.module(\'ui.router\');\n'+
+                '}'
       },
       build: {
         src: files.src,


### PR DESCRIPTION
The convention for exporting data with angular modules is to export the main module. This this even more important as ES6 is being adopted and the convention is to import modules which use a default export to expose the main module, then referring to the module's name using the 'name' property from the angular module API.

Since only the name of this module was exported, this would prevent the use of the module in the conventional ES6 way and force you to hardcode the dependency name.

This fix allows you to do:

```
import ModuleRouter from 'angular-ui-router';

let MyModule = angular.module('MyModule', [ModuleRouter.name]);

...

exports default MyModule;

```