### PR TITLE
fix(urlMatcherFactory): include the slash in squashed params

### DIFF
--- a/src/urlMatcherFactory.js
+++ b/src/urlMatcherFactory.js
@@ -103,7 +103,10 @@ function UrlMatcher(pattern, config, parentMatcher) {
     if (!pattern) return result;
     switch(squash) {
       case false: surroundPattern = ['(', ')' + (optional ? "?" : "")]; break;
-      case true:  surroundPattern = ['?(', ')?']; break;
+      case true:
+        result = result.replace(/\/$/, '');
+        surroundPattern = ['(?:\/(', ')|\/)?'];
+      break;
       default:    surroundPattern = ['(' + squash + "|", ')?']; break;
     }
     return result + surroundPattern[0] + pattern + surroundPattern[1];

--- a/test/urlMatcherFactorySpec.js
+++ b/test/urlMatcherFactorySpec.js
@@ -588,6 +588,7 @@ describe("urlMatcherFactory", function () {
         params: { id: { value: null, squash: true } }
       });
       expect(m.exec('/users/1138')).toEqual({ id: 1138 });
+      expect(m.exec('/users1138')).toBeNull();
       expect(m.exec('/users/').id).toBeNull();
       expect(m.exec('/users').id).toBeNull();
     });


### PR DESCRIPTION
Squashed params were ignoring a missing slash before the param so things
like /users123 would match /url/:id

Fixes #2064