### PR TITLE
fix (uiSrefActive): also update when stateParams change

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -250,6 +250,7 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate) {
       };
 
       $scope.$on('$stateChangeSuccess', update);
+      $scope.$on('$stateParamsChange', update);
 
       // Update route state
       function update() {

--- a/test/stateDirectivesSpec.js
+++ b/test/stateDirectivesSpec.js
@@ -401,7 +401,9 @@ describe('uiSrefActive', function() {
     $stateProvider.state('top', {
       url: ''
     }).state('contacts', {
-      url: '/contacts',
+      url: '/contacts?sortBy',
+      params: { sortBy: 'name' },
+      reloadOnSearch: false,
       views: {
         '@': {
           template: '<a ui-sref=".item({ id: 6 })" ui-sref-active="active">Contacts</a>'
@@ -440,6 +442,24 @@ describe('uiSrefActive', function() {
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
 
     $state.transitionTo('contacts.item', { id: 2 });
+    $q.flush();
+    timeoutFlush();
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
+  }));
+
+  it('should update after state\'s parameters change', inject(function($rootScope, $q, $compile, $state) {
+    el = angular.element('<div><a ui-sref="contacts({ sortBy: \'name\' })" ui-sref-active="active">Sort By Name</a></div>');
+    template = $compile(el)($rootScope);
+    $rootScope.$digest();
+
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
+    $state.transitionTo('contacts', { sortBy: 'name' });
+    $q.flush();
+    timeoutFlush();
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
+
+    $q.flush();
+    $state.transitionTo('contacts', { sortBy: 'foo' });
     $q.flush();
     timeoutFlush();
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -165,6 +165,7 @@ describe('state', function () {
     $rootScope.$on('$stateChangeStart', eventLogger);
     $rootScope.$on('$stateChangeCancel', eventLogger);
     $rootScope.$on('$stateChangeSuccess', eventLogger);
+    $rootScope.$on('$stateParamsChange', eventLogger);
     $rootScope.$on('$stateChangeError', eventLogger);
     $rootScope.$on('$stateNotFound', eventLogger);
   }));
@@ -227,6 +228,18 @@ describe('state', function () {
       $q.flush();
       expect($stateParams).toEqual({term: 'hello'});
       expect(called).toBeFalsy();
+    }));
+
+    it('trigger state params change when state.reloadOnSearch=false and only query params changed', inject(function ($state, $stateParams, $q, $location, $rootScope){
+      initStateTo(RS);
+      $location.search({term: 'hello'});
+      var called;
+      $rootScope.$on('$stateParamsChange', function (ev, to, toParams, from, fromParams) {
+        called = true
+      });
+      $q.flush();
+      expect($stateParams).toEqual({term: 'hello'});
+      expect(called).toBeTruthy();
     }));
 
     it('updates URL when changing only query params via $state.go() when reloadOnSearch=false', inject(function ($state, $stateParams, $q, $location, $rootScope){
@@ -495,7 +508,9 @@ describe('state', function () {
       $q.flush();
       expect($state.current).toBe(A);
       expect(resolvedError(superseded)).toBeTruthy();
-      expect(log).toBe('$stateChangeStart(B,A);');
+      expect(log).toBe(
+        '$stateChangeStart(B,A);' +
+        '$stateParamsChange(A,A);');
     }));
 
     it('aborts pending transitions when aborted from callbacks', inject(function ($state, $q) {


### PR DESCRIPTION
- This include a new event on the state lifecycle named
  stateParamsChange that is fired inside the skipStateTransition
scenario.

Closes #2049