### PR TITLE
feat(uiSrefActive): work when params change inside same state

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -249,7 +249,7 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate) {
         update();
       };
 
-      $scope.$on('$stateChangeSuccess', update);
+      $scope.$on('$locationChangeSuccess', update);
 
       // Update route state
       function update() {


### PR DESCRIPTION
Change uiSrefActive directive to listen to ``$locationChangeSuccess`` instead of  ``$stateChangeSuccess``. 

Closes #2049