### PR TITLE
null object pattern for state.local

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -1113,7 +1113,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
           if (exiting.self.onExit) {
             $injector.invoke(exiting.self.onExit, exiting.self, exiting.locals.globals);
           }
-          exiting.locals = null;
+          exiting.locals = {};
         }
 
         // Enter 'to' states not kept


### PR DESCRIPTION
Set `state.local` on a empty object to allow keys lookup.
fix #1833 fix #1901 