### PR TITLE
feat($state): add prependBasePath option

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -1332,7 +1332,9 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
      * - **`relative`** - {object=$state.$current}, When transitioning with relative path (e.g '^'), 
      *    defines which state to be relative from.
      * - **`absolute`** - {boolean=false},  If true will generate an absolute url, e.g. "http://www.example.com/fullurl".
-     * 
+     * - **`prependBasePath`** - {boolean=true}, If false will not prepend base path (`<base href="/path/">`) to path. Will always prepend
+     *    base path if `absolute` is true.
+     *
      * @returns {string} compiled state url
      */
     $state.href = function href(stateOrName, params, options) {
@@ -1340,7 +1342,8 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
         lossy:    true,
         inherit:  true,
         absolute: false,
-        relative: $state.$current
+        relative: $state.$current,
+        prependBasePath: true
       }, options || {});
 
       var state = findState(stateOrName, options.relative);
@@ -1354,7 +1357,8 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
         return null;
       }
       return $urlRouter.href(nav.url, filterByKeys(state.params.$$keys().concat('#'), params || {}), {
-        absolute: options.absolute
+        absolute: options.absolute,
+        prependBasePath: options.prependBasePath
       });
     };
 

--- a/src/urlRouter.js
+++ b/src/urlRouter.js
@@ -267,7 +267,7 @@ function $UrlRouterProvider(   $locationProvider,   $urlMatcherFactory) {
 
     var baseHref = $browser.baseHref(), location = $location.url(), lastPushedUrl;
 
-    function appendBasePath(url, isHtml5, absolute) {
+    function prependBasePath(url, isHtml5, absolute) {
       if (baseHref === '/') return url;
       if (isHtml5) return baseHref.slice(0, -1) + url;
       if (absolute) return baseHref.slice(1) + url;
@@ -386,6 +386,8 @@ function $UrlRouterProvider(   $locationProvider,   $urlMatcherFactory) {
        * @param {object=} options Options object. The options are:
        *
        * - **`absolute`** - {boolean=false},  If true will generate an absolute url, e.g. "http://www.example.com/fullurl".
+       * - **`prependBasePath`** - {boolean=true}, If false will not prepend base path (`<base href="/path/">`) to path. Will always prepend
+       *    base path if `absolute` is true.
        *
        * @returns {string} Returns the fully compiled URL, or `null` if `params` fail validation against `urlMatcher`
        */
@@ -411,7 +413,9 @@ function $UrlRouterProvider(   $locationProvider,   $urlMatcherFactory) {
           url += '#' + params['#'];
         }
 
-        url = appendBasePath(url, isHtml5, options.absolute);
+        if (options.absolute || options.prependBasePath) {
+          url = prependBasePath(url, isHtml5, options.absolute);
+        }
 
         if (!options.absolute || !url) {
           return url;

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -958,6 +958,18 @@ describe('state', function () {
         expect($state.href("home")).toEqual("/base/");
         expect($state.href("home", null, { absolute: true })).toEqual("http://server/base/");
       }));
+
+      describe('base path prepending', function() {
+        it('should not prepend when argument is non-truthy', inject(function($state) {
+          locationProvider.html5Mode(true);
+          expect($state.href("home", null, { prependBasePath: false })).toEqual("/");
+        }));
+
+        it('should ignore prependBasePath option for absolute URLs', inject(function($state) {
+          locationProvider.html5Mode(true);
+          expect($state.href("home", null, { prependBasePath: false, absolute: true })).toEqual("http://server/base/");
+        }));
+      });
     });
   });
 


### PR DESCRIPTION
Also s/appendBasePath/prependBasePath/g

So, I want to generate a non-absolute href without the base path prepended and couldn't find a way of doing that.