### PR TITLE
Replace `declare ng.ui` with `declare angular.ui`.  Fixes #2035

### DIFF
--- a/api/angular-ui-router.d.ts
+++ b/api/angular-ui-router.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Michel Salib <https://github.com/michelsalib>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare module ng.ui {
+declare angular.ui {
 
     interface IState {
         name?: string;
@@ -11,7 +11,7 @@ declare module ng.ui {
         templateUrl?: any; // string || () => string
         templateProvider?: any; // () => string || IPromise<string>
         controller?: any;
-        controllerAs?: string;    
+        controllerAs?: string;
         controllerProvider?: any;
         resolve?: {};
         url?: string;
@@ -118,7 +118,7 @@ declare module ng.ui {
 
     interface IUiViewScrollProvider {
         /*
-         * Reverts back to using the core $anchorScroll service for scrolling 
+         * Reverts back to using the core $anchorScroll service for scrolling
          * based on the url anchor.
          */
         useAnchorScroll(): void;


### PR DESCRIPTION
Because the TS 1.5 language service does not yet support the exclude option, IDEs such as WebStorm will find and use angular-ui-router.d.ts.

As discussed in issue 2035, the declaration ng.ui conflicts with the declaration of ng in angular.d.ts.

This merge is to correct the declaration from ng.ui to angular.ui

Pull 1990 is attempting to address the issue by removing the definition entirely from the project, which is fine as well.

Either way, the issue is a blocker for those compiling with an IDE (i.e. perhaps not using  a gulpfile).

Hopefully one of the two pulls will be merged ASAP.

Fixes #2035 