### PR TITLE
feat(uiState): add ui-state directive

### DIFF
--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -542,7 +542,7 @@ describe('state', function () {
       $state.transitionTo('dynamicController', { type: "Acme" });
       $q.flush();
       expect(ctrlName).toEqual("AcmeFooController");
-    }));+
+    }));
 
     it('uses the templateProvider to get template dynamically', inject(function ($state, $q) {
       $state.transitionTo('dynamicTemplate', { type: "Acme" });


### PR DESCRIPTION
 - Refactor StateRefDirective for better modularity
 - Drop key restrictions on ui-sref-opts
 - Improves performance over prior implementation with no extra $eval()’s

Fixes #395, #900, #1932

cc: @kasperlewau @christopherthielen