### PR TITLE
feat($IncludedByStateFilter): add parameters to $IncludedByStateFilter

### DIFF
--- a/src/state/stateFilters.ts
+++ b/src/state/stateFilters.ts
@@ -27,8 +27,8 @@ export function $IsStateFilter($state) {
  */
 $IncludedByStateFilter.$inject = ['$state'];
 export function $IncludedByStateFilter($state) {
-  return function(state) {
-    return $state.includes(state);
+  return function(state, params, options) {
+    return $state.includes(state, params, options);
   };
 }
 

--- a/test/stateFiltersSpec.js
+++ b/test/stateFiltersSpec.js
@@ -28,7 +28,8 @@ describe('includedByState filter', function() {
     $stateProvider
       .state('a', { url: '/' })
       .state('a.b', { url: '/b' })
-      .state('c', { url: '/c' });
+      .state('c', { url: '/c' })
+      .state('d', { url: '/d/:id' });
   }));
 
   it('should return true if the current state exactly matches the input state', inject(function($parse, $state, $q, $rootScope) {
@@ -47,5 +48,17 @@ describe('includedByState filter', function() {
     $state.go('c');
     $q.flush();
     expect($parse('"a" | includedByState')($rootScope)).toBe(false);
+  }));
+
+  it('should return true if the current state include input state and params', inject(function($parse, $state, $q, $rootScope) {
+    $state.go('d', { id: 123 });
+    $q.flush();
+    expect($parse('"d" | includedByState:{ id: 123 }')($rootScope)).toBe(true);
+  }));
+
+  it('should return false if the current state does not include input state and params', inject(function($parse, $state, $q, $rootScope) {
+    $state.go('d', { id: 2377 });
+    $q.flush();
+    expect($parse('"d" | includedByState:{ id: 123 }')($rootScope)).toBe(false);
   }));
 });


### PR DESCRIPTION
PR linked to #1736 but for version feature-1.0

Add parameters to the $IncludedByStateFilter:
- params
- options

This allows to use more parameters on this filter and not only the fullOrPartialStatename parameter.
Thanks to this improvement, the following now works (takes in account the id param):

`<div ng-show="'**.foo.**' | includedByState:{id: 'new'}">It works</div>`

Related doc: http://angular-ui.github.io/ui-router/site/#/api/ui.router.state.$state#methods_includes