### PR TITLE
$stateParams reset between tests

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -1461,5 +1461,5 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
 }
 
 angular.module('ui.router.state')
-  .value('$stateParams', {})
+  .factory('$stateParams', function () { return {}; })
   .provider('$state', $StateProvider);

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -1490,3 +1490,18 @@ describe('state queue', function(){
     });
   });
 });
+
+describe('$stateParams', function () {
+  beforeEach(module('ui.router.state'));
+
+  it('should start empty', inject(function ($stateParams) {
+    expect($stateParams.foo).toBeUndefined();
+  }));
+  it('should allow setting values on it', inject(function ($stateParams) {
+    $stateParams.foo = 'bar';
+    expect($stateParams.foo).toBeDefined();
+  }));
+  it('should be cleared between tests', inject(function ($stateParams) {
+    expect($stateParams.foo).toBeUndefined();
+  }));
+});


### PR DESCRIPTION
Fixes issue with changes to $stateParams leaking from one test case into another. Functionality is otherwise unaffected.