### PR TITLE
Add main field to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,5 +19,6 @@
     "ngdoc_assets",
     "Gruntfile.js",
     "files.js"
-  ]
+  ],
+  "main": "release/angular-ui-router.js"
 }


### PR DESCRIPTION
This adds a `main` field to the `bower.json` file for better interoperability with tools like `wiredep`.