### PR TITLE
Regarding documentation typo #2203

### DIFF
--- a/src/urlMatcherFactory.js
+++ b/src/urlMatcherFactory.js
@@ -289,7 +289,7 @@ UrlMatcher.prototype.parameters = function (param) {
 
 /**
  * @ngdoc function
- * @name ui.router.util.type:UrlMatcher#validate
+ * @name ui.router.util.type:UrlMatcher#validates
  * @methodOf ui.router.util.type:UrlMatcher
  *
  * @description


### PR DESCRIPTION
The doc comment for `UrlMatcher.prototype.validates` was missing the 's' on validates. In other words,

`@name ui.router.util.type:UrlMatcher#validate`

to

`@name ui.router.util.type:UrlMatcher#validates`


https://github.com/angular-ui/ui-router/issues/2203