### PR TITLE
feat($state): make state data inheritance prototypical

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -41,7 +41,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
     // inherit 'data' from parent and override by own values (if any)
     data: function(state) {
       if (state.parent && state.parent.data) {
-        state.data = state.self.data = extend({}, state.parent.data, state.data);
+        state.data = state.self.data = inherit(state.parent.data, state.data);
       }
       return state.data;
     },

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -1338,6 +1338,7 @@ describe('state', function () {
       expect($state.current.name).toEqual('HHH');
       expect($state.current.data.propA).toEqual(HHH.data.propA);
       expect($state.current.data.propB).toEqual(H.data.propB);
+      expect($state.current.data.hasOwnProperty('propB')).toBe(false);
       expect($state.current.data.propB).toEqual(HH.data.propB);
       expect($state.current.data.propC).toEqual(HHH.data.propC);
     }));


### PR DESCRIPTION
Modify state data inheritance to use prototypical inhertiance rather than Angular's extend method to enable more flexibility in handling state data.

### Justification
I'm currently working on a project that implements Material Design via Angular Material. We've implemented a global [FAB](https://www.google.com/design/spec/components/buttons-floating-action-button.html) by attaching information about what the FAB should do to the state definition. For example:

```javascript
angular.module('MyMaterialDesignProject')
  .config(function($stateProvider) {
    $stateProvider
      .state('foo', {
        url: '/foo',
        data: {
          primaryAction: {
            onClick: function($state) {
              $state.go('foo.bar');
            }
          }
        }
      })
      .state('foo.bar', {
        url: '/bar'
      });
  });
```

When we arrive at `foo.bar` we need to be able to tell if `data.primaryAction` is defined as part of the `foo.bar` state definition or if it's inherited. If it's inherited we (maybe) don't want to display the FAB.

### Risk of breaking change
Any dev who has implemented a test to determine the availability of a data property using `data.hasOwnProperty('foo')` rather than something like `'foo' in data` is at risk of having their app stop functioning as they expect.