### PR TITLE
Revert "feat(UrlMatcher): Add param only type names"

### DIFF
--- a/src/urlMatcherFactory.js
+++ b/src/urlMatcherFactory.js
@@ -917,8 +917,7 @@ function $UrlMatcherFactory() {
     }
 
     function getType(config, urlType, location) {
-      if (config.type && urlType.name !== 'string') throw new Error("Param '"+id+"' has two type configurations.");
-      if (config.type && urlType.name === 'string' && $types[config.type]) return $types[config.type];
+      if (config.type && urlType) throw new Error("Param '"+id+"' has two type configurations.");
       if (urlType) return urlType;
       if (!config.type) return (location === "config" ? $types.any : $types.string);
       return config.type instanceof Type ? config.type : new Type(config.type);

--- a/test/urlMatcherFactorySpec.js
+++ b/test/urlMatcherFactorySpec.js
@@ -520,21 +520,6 @@ describe("urlMatcherFactory", function () {
       expect(m.format({ foo: 5, flag: true })).toBe("/5/1");
     });
 
-    it("should match types named only in params", function () {
-      var m = new UrlMatcher("/{foo}/{flag}", {
-        params: {
-          foo: {
-            type: 'int'
-          },
-          flag: {
-            type: 'bool'
-          }
-        }
-      });
-      expect(m.exec("/1138/1")).toEqual({ foo: 1138, flag: true });
-      expect(m.format({ foo: 5, flag: true })).toBe("/5/1");
-    });
-
     it("should encode/decode dates", function () {
       var m = new UrlMatcher("/calendar/{date:date}"),
           result = m.exec("/calendar/2014-03-26");


### PR DESCRIPTION
Reverts angular-ui/ui-router#2289

After talking with @christopherthielen, this likely breaks cases that we realized we don't have test coverage for, so that needs to be fixed before this can be addressed. Sorry for the confusion.