### PR TITLE
Throws an error if the invocation of a resolve function fails

### DIFF
--- a/src/resolve.js
+++ b/src/resolve.js
@@ -111,6 +111,7 @@ function $Resolve(  $q,    $injector) {
       function fail(reason) {
         result.$$failure = reason;
         resolution.reject(reason);
+        throw reason;
       }
 
       // Short-circuit if parent has already failed


### PR DESCRIPTION
Thrown errors from `$injector.invoke` get lost at https://github.com/angular-ui/ui-router/blob/master/src/resolve.js#L174.

This pull request will re-throw the error for better debugging. Otherwise you'll get lost in debugging broken resolve functions :)

In my case, Angular could not create a service properly. The state didn't resolved without an error.