### PR TITLE
feat(uiViewCache): outer most views can now be reused

### DIFF
--- a/sample/app/app.js
+++ b/sample/app/app.js
@@ -56,17 +56,36 @@ angular.module('uiRouterSample', [
 
           // Use a url of "/" to set a state as the "index".
           url: "/",
-
+          persistent:true,
+          controller: ['$scope','$timeout',function($scope, $timeout){
+            $scope.date = new Date();
+            $scope.invalidated = false;
+            $scope.restored = false;
+            $scope.cleanCache = angular.noop;
+            $scope.$on('$viewRestored', function(evt, name){
+                $scope.restored = true;
+                var expires = new Date();
+                expires.setSeconds(expires.getSeconds()-10);
+                if($scope.date < expires){
+                  $scope.invalidated = true;
+                  $scope.cleanCache();
+                }
+            });
+            $scope.$on('$viewCached', function(evt, data){
+              $scope.cleanCache = data.reset;
+            });
+          }],
           // Example of an inline template string. By default, templates
           // will populate the ui-view within the parent state's template.
           // For top level states, like this one, the parent template is
           // the index.html file. So this template will be inserted into the
           // ui-view within index.html.
-          template: '<p class="lead">Welcome to the UI-Router Demo</p>' +
+          template: '<p class="lead">Welcome to the UI-Router {{restored?"restored ":"fresh "}}{{invalidated?"but now invalidated ":""}}Demo</p>' +
             '<p>Use the menu above to navigate. ' +
             'Pay attention to the <code>$state</code> and <code>$stateParams</code> values below.</p>' +
             '<p>Click these links—<a href="#/c?id=1">Alice</a> or ' +
-            '<a href="#/user/42">Bob</a>—to see a url redirect in action.</p>'
+            '<a href="#/user/42">Bob</a>—to see a url redirect in action.</p>'+
+            'Generation date: {{date}}'
 
         })
 

--- a/sample/app/contacts/contacts.js
+++ b/sample/app/contacts/contacts.js
@@ -62,7 +62,8 @@ angular.module('uiRouterSample.contacts', [
         // Using a '.' within a state name declares a child within a parent.
         // So you have a new state 'list' within the parent 'contacts' state.
         .state('contacts.list', {
-
+          // it is ok to enable this flag for leafnodes (view that doesnt have inner views)
+          persistent: true,
           // Using an empty url means that this child state will become active
           // when its parent's url is navigated to. Urls of child states are
           // automatically appended to the urls of their parent. So this state's


### PR DESCRIPTION
This PR resolves https://github.com/angular-ui/ui-router/issues/1800 and enables reusable / persistent views. When user navigates to a persistent state it will be exactly as it was before navigating away. This greatly improves user experience if you are targeting mobile apps or have complex elements in page.

By adding 'persistent:true' flag to a state config you indicate that it is reusable. Such states will only be initialized once and through the use of additional events you can control what happens when user revisit same state and control it's lifetime. 

There are 2 additional events:
- **$viewRestored** can be used to do partial updates to a view. E.g. change location of map pins based on different state.params, reload list view when search criteria changes, etc.).
- **$viewCached** provides you a `reset` function that will clear cache of this view so that it would be reinitialized next time user navigates to this state.

and there are 2 quirks:
- Only leaf nodes are supported. Behavior is undefined for views that has inner views. 
- Since DOM node is detached, scroll position is lost. Directive below can be used to overcome this issue. It might be ok to handle this automatically, but some input would be needed from $viewRestored event - this is the place where developer would know whether view is going to be refreshed or not.

```
(function (module) {
    var DATA_PROP = '_scrollTop';
    module.directive('persistentScroll', function ($timeout) {
        return {
            restrict: 'A',
            link: function (_scope, _element) {
                _scope.$on('$viewRestored', function () {
                    _element.scrollTop(_element.data(DATA_PROP)||0);
                });
                _element.data(DATA_PROP, 0);
                _element.on('scroll', function () {
                    $timeout(function () {
                        _element.data(DATA_PROP, _element.scrollTop());
                    });
                });
            }
        };
    });
    // The name of the module, followed by its dependencies (at the bottom to facilitate enclosure)
}(angular.module("app.persistent-scroll", [
])));
```
