### PR TITLE
feat(includedByStateFilter): Include optional state params.

### DIFF
--- a/src/stateFilters.js
+++ b/src/stateFilters.js
@@ -27,8 +27,8 @@ function $IsStateFilter($state) {
  */
 $IncludedByStateFilter.$inject = ['$state'];
 function $IncludedByStateFilter($state) {
-  var includesFilter = function (state) {
-    return $state.includes(state);
+  var includesFilter = function (state, params) {
+    return $state.includes(state, params);
   };
   includesFilter.$stateful = true;
   return  includesFilter;

--- a/test/stateFiltersSpec.js
+++ b/test/stateFiltersSpec.js
@@ -38,7 +38,8 @@ describe('includedByState filter', function() {
     $stateProvider
       .state('a', { url: '/' })
       .state('a.b', { url: '/b' })
-      .state('c', { url: '/c' });
+      .state('c', { url: '/c' })
+      .state('with-param', { url: '/with/:param' });
   }));
 
   it('should return true if the current state exactly matches the input state', inject(function($parse, $state, $q, $rootScope) {
@@ -57,5 +58,17 @@ describe('includedByState filter', function() {
     $state.go('c');
     $q.flush();
     expect($parse('"a" | includedByState')($rootScope)).toBe(false);
+  }));
+
+  it('should return true if the current state and param includes the input state', inject(function($parse, $state, $q, $rootScope) {
+    $state.go('with-param', {param: 'a'});
+    $q.flush();
+    expect($parse('"with-param" | includedByState: {param: "a"}')($rootScope)).toBe(true);
+  }));
+
+  it('should return false if the current state and param does not include input state', inject(function($parse, $state, $q, $rootScope) {
+    $state.go('with-param', {param: 'b'});
+    $q.flush();
+    expect($parse('"with-param" | includedByState: {param: "a"}')($rootScope)).toBe(false);
   }));
 });


### PR DESCRIPTION
Allows state params to be passed to the `includedByState` filter for more accurate matching.
