### PR TITLE
fix(stateDirectives): call update route state on page load

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -367,6 +367,7 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate) {
           }
         }
       }
+      update();
 
       function addClass(el, className) { $timeout(function () { el.addClass(className); }); }
       function removeClass(el, className) { el.removeClass(className); }


### PR DESCRIPTION
The latest PR #2363  removed a [line](https://github.com/angular-ui/ui-router/commit/539e207731daaafda34876a462d6624a12bfe03b#diff-544b7ce9751e1a566e17d486dd4ab576L291) from `stateDirectives.js`. This creates an issue. More precisely, when the page is loaded the [update()](https://github.com/angular-ui/ui-router/blob/master/src/stateDirectives.js#L355) function is not called the way it is expected.
Let me clarify this on an example:
Lets assume that we have an abstract state `private`. The `private` state has children states: `index` and `settings`. With routes `#/private` and `#/settings`.
And we have a navbar:
```
<ul>
  <li ui-sref-active="{'active': 'private'}"  class="parent">Private</li>
  <ul>
    <li>
      <a ui-sref="private.index">main</a>
    </li>
    <li>
      <a ui-sref="private.settings">settings</a>
    </li>
  </ul>
</ul>
```  
![screen shot 2015-11-25 at 12 56 22](https://cloud.githubusercontent.com/assets/4527650/11395463/f4585c7c-9373-11e5-82e6-1e776513044a.png)

Here we assume that every time we are in the `index` and `settings` ui-router should append class `.active` to `.parent` element. But in fact it never appends it on page load. It only appends it when the user clicks `<a ui-sref="private.index">main</a>` or `<a ui-sref="private.settings">settings</a>` links. Thats because the [update](https://github.com/angular-ui/ui-router/blob/master/src/stateDirectives.js#L355) is never called on page load. This PR solves the issue.