### PR TITLE
docs(method:go): clarify param: params

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -883,8 +883,8 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
      *
      * @param {object=} params A map of the parameters that will be sent to the state, 
      * will populate $stateParams. Any parameters that are not specified will be inherited from currently 
-     * defined parameters. Only parameters specified in the state definition can be overridden, new 
-     * parameters will be ignored. This allows, for example, going to a sibling state that shares parameters
+     * defined parameters. Only parameters specified in the state definition can be overridden, new parameters
+     * will be ignored. This allows, for example, going to a sibling state that shares parameters
      * specified in a parent state. Parameter inheritance only works between common ancestor states, I.e.
      * transitioning to a sibling will get you the parameters for all parents, transitioning to a child
      * will get you all current parameters, etc.


### PR DESCRIPTION
At line 886 the sentence: Only parameters specified in the state definition can be overridden, new parameters will be ignored. DOES NOT show up in the online version 'that can be improved.' This sentence is VITAL to understanding the method. Please ensure the online version shows this sentence. -- thanks.