### PR TITLE
fix(urlMatcherFactory.js): change to allow url query param names to c…

### DIFF
--- a/src/urlMatcherFactory.js
+++ b/src/urlMatcherFactory.js
@@ -82,7 +82,7 @@ function UrlMatcher(pattern, config, parentMatcher) {
   //    \\.                            - a backslash escape
   //    \{(?:[^{}\\]+|\\.)*\}          - a matched set of curly braces containing other atoms
   var placeholder       = /([:*])([\w\[\]]+)|\{([\w\[\]]+)(?:\:\s*((?:[^{}\\]+|\\.|\{(?:[^{}\\]+|\\.)*\})+))?\}/g,
-      searchPlaceholder = /([:]?)([\w\[\]-]+)|\{([\w\[\]-]+)(?:\:\s*((?:[^{}\\]+|\\.|\{(?:[^{}\\]+|\\.)*\})+))?\}/g,
+      searchPlaceholder = /([:]?)([\w\[\].-]+)|\{([\w\[\].-]+)(?:\:\s*((?:[^{}\\]+|\\.|\{(?:[^{}\\]+|\\.)*\})+))?\}/g,
       compiled = '^', last = 0, m,
       segments = this.segments = [],
       parentParams = parentMatcher ? parentMatcher.params : {},
@@ -92,7 +92,7 @@ function UrlMatcher(pattern, config, parentMatcher) {
   function addParameter(id, type, config, location) {
     paramNames.push(id);
     if (parentParams[id]) return parentParams[id];
-    if (!/^\w+(-+\w+)*(?:\[\])?$/.test(id)) throw new Error("Invalid parameter name '" + id + "' in pattern '" + pattern + "'");
+    if (!/^\w+([-.]+\w+)*(?:\[\])?$/.test(id)) throw new Error("Invalid parameter name '" + id + "' in pattern '" + pattern + "'");
     if (params[id]) throw new Error("Duplicate parameter name '" + id + "' in pattern '" + pattern + "'");
     params[id] = new $$UMFP.Param(id, type, config, location);
     return params[id];

--- a/test/urlMatcherFactorySpec.js
+++ b/test/urlMatcherFactorySpec.js
@@ -88,6 +88,28 @@ describe("UrlMatcher", function () {
     });
   });
 
+  describe("parameters containing periods", function() {
+    it("should match if properly formatted", function() {
+      var matcher = new UrlMatcher('/users/?from&to&with.periods&with.periods.also');
+      var params = matcher.parameters();
+
+      expect(params.length).toBe(4);
+      expect(params).toContain('from');
+      expect(params).toContain('to');
+      expect(params).toContain('with.periods');
+      expect(params).toContain('with.periods.also');
+      expect(matcher.parameters()).toEqual(['from','to','with.periods','with.periods.also']);
+    });
+
+    it("should not match if invalid", function() {
+      var err = "Invalid parameter name '.periods' in pattern '/users/?from&to&.periods'";
+      expect(function() { new UrlMatcher('/users/?from&to&.periods'); }).toThrow(err);
+
+      err = "Invalid parameter name 'periods.' in pattern '/users/?from&to&periods.'";
+      expect(function() { new UrlMatcher('/users/?from&to&periods.'); }).toThrow(err);
+    });
+  });  
+
   describe(".exec()", function() {
     it("should capture parameter values", function () {
       var m = new UrlMatcher('/users/:id/details/{type}/{repeat:[0-9]+}?from&to');


### PR DESCRIPTION
…ontain periods

This change modifies the searchPlaceholder regex to include the period
character as valid for url query param names. This change also modifies
the regex found in the addParameter function which validates the param
name just prior to adding to the list of parameters. A new set of unit
tests were added to urlMatcherFactorySpec to ensure this modification
works correctly.

This change fixes issue [#2395](https://github.com/angular-ui/ui-router/issues/2395)