### PR TITLE
fix(uiSrefActive): update the active classes when compiled

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -372,6 +372,8 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate) {
       function removeClass(el, className) { el.removeClass(className); }
       function anyMatch(state, params) { return $state.includes(state.name, params); }
       function exactMatch(state, params) { return $state.is(state.name, params); }
+
+      update();
     }]
   };
 }

--- a/test/stateDirectivesSpec.js
+++ b/test/stateDirectivesSpec.js
@@ -680,6 +680,16 @@ describe('uiSrefActive', function() {
       expect(el[0].className).toMatch(/admin/);
       expect(el[0].className).not.toMatch(/contacts/);
     }));
+
+    it('should update the active classes when compiled', inject(function($compile, $rootScope, $document, $state, $q) {
+      $state.transitionTo('admin.roles');
+      $q.flush();
+      timeoutFlush();
+      el = $compile('<div ui-sref-active="{active: \'admin.roles\'}"/>')($rootScope);
+      $rootScope.$digest();
+      timeoutFlush();
+      expect(el.hasClass('active')).toBeTruthy();
+    }));
   });
 });
 


### PR DESCRIPTION
This PR makes sure the active classes are applied during the directive compilation phase so that they are available even after `$stateChangeSuccess` has already been fired.

This patch was originally developed for `1.0.0alpha0`, but since the test for it didn't pass on master either, I've backported it.

Plunkr showing the issue: https://plnkr.co/edit/z3kdm41eyuXK052fsflH?p=preview