### PR TITLE
fix(uiSrefActive): update the active classes when compiled

### DIFF
--- a/src/ng1/stateDirectives.ts
+++ b/src/ng1/stateDirectives.ts
@@ -329,6 +329,7 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate) {
 
       function exactMatch(state, params) { return $state.is(state.name, params); }
 
+      update();
     }]
   };
 }

--- a/test/stateDirectivesSpec.js
+++ b/test/stateDirectivesSpec.js
@@ -661,5 +661,15 @@ describe('uiSrefActive', function() {
       expect(el[0].className).toMatch(/admin/);
       expect(el[0].className).not.toMatch(/contacts/);
     }));
+
+    it('should update the active classes when compiled', inject(function($compile, $rootScope, $document, $state, $q) {
+      $state.transitionTo('admin.roles');
+      $q.flush();
+      timeoutFlush();
+      el = $compile('<div ui-sref-active="{active: \'admin.roles\'}"/>')($rootScope);
+      $rootScope.$digest();
+      timeoutFlush();
+      expect(el.hasClass('active')).toBeTruthy();
+    }));
   });
 });


### PR DESCRIPTION
This PR makes sure the active classes are applied during the directive compilation phase so that they are available even after `$stateChangeSuccess` has already been fired.

Plunker showing the issue: https://plnkr.co/edit/z3kdm41eyuXK052fsflH?p=preview