### PR TITLE
fix(transitionTo): re-added the saved hash before broadcasting event

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -1048,7 +1048,10 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
 
       // Filter parameters before we pass them to event handlers etc.
       toParams = filterByKeys(to.params.$$keys(), toParams || {});
-
+      
+      // Re-add the saved hash before we start returning things or broadcasting $stateChangeStart
+      if (hash) toParams['#'] = hash;
+      
       // Broadcast start event and cancel the transition if requested
       if (options.notify) {
         /**
@@ -1125,9 +1128,6 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
             $injector.invoke(entering.self.onEnter, entering.self, entering.locals.globals);
           }
         }
-
-        // Re-add the saved hash before we start returning things
-        if (hash) toParams['#'] = hash;
 
         // Run it again, to catch any transitions in callbacks
         if ($state.transition !== transition) return TransitionSuperseded;

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -570,6 +570,18 @@ describe('state', function () {
       expect($location.url()).toBe('/front/world#frag');
       expect($location.hash()).toBe('frag');
     }));
+    
+    it('has access to the #fragment in $stateChangeStart hook', inject(function ($state, $q, $location, $rootScope) {
+        var hash_accessible = false;
+        $rootScope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams) {
+            hash_accessible = toParams['#'] === 'frag';
+        });
+        
+        $state.transitionTo('home.item', {id: 'world', '#': 'frag'});
+        $q.flush();
+        
+        expect(hash_accessible).toBe(true);
+    }));
   });
 
   describe('.go()', function () {


### PR DESCRIPTION
Re-added the saved hash before broadcasting $stateChangeStart. This way, libraries using this event to do their magic will have the hash accessible through toParams. (e.g. https://github.com/Narzerus/angular-permission)

Thoughts/comments ?