### PR TITLE
fix(common.js): "Cannot read property 'params' of undefined" errors

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -97,7 +97,7 @@ function inheritParams(currentParams, newParams, $current, $to) {
   var parents = ancestors($current, $to), parentParams, inherited = {}, inheritList = [];
 
   for (var i in parents) {
-    if (!parents[i].params) continue;
+    if (!parents[i] || !parents[i].params) continue;
     parentParams = objectKeys(parents[i].params);
     if (!parentParams.length) continue;
 


### PR DESCRIPTION
Fixes #2327, kudos to @pocesar