### PR TITLE
style(npmignore): add bower_components folder to ignore list

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@
 /ngdoc_assets
 /sample
 /test
+/bower_components
 Gruntfile.js
 files.js
 


### PR DESCRIPTION
PR to exclude bower_components folder when publish packages to NPM registry, it´s related to #1683 