### PR TITLE
Prevent resurrection of nulled search params when returning to parent

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -1143,7 +1143,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
         $state.transition = null;
 
         if (options.location && to.navigable) {
-          $urlRouter.push(to.navigable.url, to.navigable.locals.globals.$stateParams, {
+          $urlRouter.push(to.navigable.url, toParams, {
             $$avoidResync: true, replace: options.location === 'replace'
           });
         }


### PR DESCRIPTION
Given states that look like this:

``` javascript
$stateProvider
.state('parent', {
  url: '/parent?query',
  params: {
    query: {
      value: null,
      squash: true
    }
  },
  reloadOnSearch: false,
  ...
})
.state('parent.child', {
  url: '/:param',
  reloadOnSearch: false,
  ...
});
```

navigate to `/parent?query=foo` so that the initial page load includes the search parameter. This is important: the bug does not occur unless the app is initially loaded from a URL _with_ the search parameter.

Then navigate down to the child:

``` javascript
$state.go('parent.child', {query: 'foo', param: 'bar'});
```

Then pop off the search parameter:

``` javascript
$state.go('parent.child', {query: null, param: 'bar'});
```

And finally pop back out to the parent:

``` javascript
$state.go('parent', {query: null});
```

`$location.url()` will be `/parent?query=foo` instead of `/parent` and `$state.params.query` will be `'foo'` instead of `null`.

Cause appears to be reuse of old `$stateParams` from `to.navigable.locals.globals` when making the transition. These state params never get updated after the initial page load, and are therefore unaware that we nulled `query`. 350d3e8 refreshes `to.locals.globals.$stateParams`, but not `to.navigable.locals.globals.$stateParams`. Fix is to simply use `toParams` in the final `$urlRouter.push()` call instead.

Cannot reproduce in plunkr because plunkr does not support loading the app at an arbitrary URL, but I've written a test that fails with the old code and passes with the new code.
