### PR TITLE
docs(resolve): fix a typo

### DIFF
--- a/src/resolve.js
+++ b/src/resolve.js
@@ -216,7 +216,7 @@ function $Resolve(  $q,    $injector) {
    * propagated immediately. Once the `$resolve` promise has been rejected, no 
    * further invocables will be called.
    * 
-   * Cyclic dependencies between invocables are not permitted and will caues `$resolve`
+   * Cyclic dependencies between invocables are not permitted and will cause `$resolve`
    * to throw an error. As a special case, an injectable can depend on a parameter 
    * with the same name as the injectable, which will be fulfilled from the `parent` 
    * injectable of the same name. This allows inherited values to be decorated. 


### PR DESCRIPTION
Found a spelling mistake -
`caues` → `cause`