### PR TITLE
Expose animation promises as element data

### DIFF
--- a/src/ng1/viewDirective.ts
+++ b/src/ng1/viewDirective.ts
@@ -1,5 +1,3 @@
-var ngMajorVer = angular.version.major;
-var ngMinorVer = angular.version.minor;
 /** @module view */ /** for typedoc */
 import {extend} from "../common/common";
 import {isDefined} from "../common/predicates";
@@ -30,9 +28,6 @@ import {UIViewData} from "../view/interface";
  * when a view is populated. By default, $anchorScroll is overridden by ui-router's custom scroll
  * service, {@link ui.router.state.$uiViewScroll}. This custom service let's you
  * scroll ui-view elements into view when they are populated during a state activation.
- *
- * @param {string=} noanimation If truthy, the non-animated renderer will be selected (no animations
- * will be applied to the ui-view)
  *
  * *Note: To revert back to old [`$anchorScroll`](http://docs.angularjs.org/api/ng.$anchorScroll)
  * functionality, call `$uiViewScrollProvider.useAnchorScroll()`.*
@@ -127,26 +122,16 @@ $ViewDirective.$inject = ['$view', '$animate', '$uiViewScroll', '$interpolate', 
 function $ViewDirective(   $view,   $animate,   $uiViewScroll,   $interpolate,   $q) {
 
   function getRenderer(attrs, scope) {
-
-    function animEnabled(element) {
-      if (!!attrs.noanimation) return false;
-      return (ngMajorVer === 1 && ngMinorVer >= 4) ? !!$animate.enabled(element) : !!$animate.enabled();
-    }
-
     return {
       enter: function(element, target, cb) {
-        if (!animEnabled(element)) {
-          target.after(element); cb();
-        } else if (angular.version.minor > 2) {
+        if (angular.version.minor > 2) {
           $animate.enter(element, null, target).then(cb);
         } else {
           $animate.enter(element, null, target, cb);
         }
       },
       leave: function(element, cb) {
-        if (!animEnabled(element)) {
-          element.remove(); cb();
-        } else if (angular.version.minor > 2) {
+        if (angular.version.minor > 2) {
           $animate.leave(element).then(cb);
         } else {
           $animate.leave(element, cb);

--- a/src/ng1/viewDirective.ts
+++ b/src/ng1/viewDirective.ts
@@ -177,7 +177,7 @@ function $ViewDirective(   $view,   $animate,   $uiViewScroll,   $interpolate,  
         trace.traceUiViewEvent("Linking", viewData);
 
         function configUpdatedCallback(config?: ViewConfig) {
-          if (configsEqual(viewConfig, config) || scope._willBeDestroyed) return;
+          if (configsEqual(viewConfig, config)) return;
           trace.traceUiViewConfigUpdated(viewData, config && config.context);
 
           viewConfig = config;
@@ -195,42 +195,27 @@ function $ViewDirective(   $view,   $animate,   $uiViewScroll,   $interpolate,  
         });
 
         function cleanupLastView() {
-          var _previousEl = previousEl;
-          var _currentScope = currentScope;
-
-          if (_currentScope) {
-            _currentScope._willBeDestroyed = true;
+          if (previousEl) {
+            trace.traceUiViewEvent("Removing    (previous) el", viewData);
+            previousEl.remove();
+            previousEl = null;
           }
 
-          function cleanOld() {
-            if (_previousEl) {
-              trace.traceUiViewEvent("Removing    (previous) el", viewData);
-              _previousEl.remove();
-              _previousEl = null;
-            }
-
-            if (_currentScope) {
-              trace.traceUiViewEvent("Destroying  (previous) scope", viewData);
-              _currentScope.$destroy();
-              _currentScope = null;
-            }
+          if (currentScope) {
+            trace.traceUiViewEvent("Destroying  (previous) scope", viewData);
+            currentScope.$destroy();
+            currentScope = null;
           }
 
           if (currentEl) {
             trace.traceUiViewEvent("Animate out (previous)", viewData);
             renderer.leave(currentEl, function() {
-              cleanOld();
               previousEl = null;
             });
 
             previousEl = currentEl;
-          } else {
-            cleanOld();
-            previousEl = null;
+            currentEl = null;
           }
-
-          currentEl = null;
-          currentScope = null;
         }
 
         function updateView(config?: ViewConfig) {

--- a/test/viewDirectiveSpec.js
+++ b/test/viewDirectiveSpec.js
@@ -14,7 +14,7 @@ function animateFlush($animate) {
 describe('uiView', function () {
   'use strict';
 
-  var log, scope, $compile, elem;
+  var scope, $compile, elem;
 
   beforeEach(function() {
     var depends = ['ui.router'];
@@ -36,10 +36,6 @@ describe('uiView', function () {
       return jasmine.createSpy('$uiViewScroll');
     });
   }));
-
-  beforeEach(function() {
-    log = '';
-  });
 
   var aState = {
     template: 'aState template'
@@ -112,9 +108,8 @@ describe('uiView', function () {
       }
     }
   },
-
-  oState = {
-    template: 'oState',
+  mState = {
+    template: 'mState',
     controller: function ($scope, $element) {
       $scope.elementId = $element.attr('id');
     }
@@ -134,22 +129,7 @@ describe('uiView', function () {
       .state('j', jState)
       .state('k', kState)
       .state('l', lState)
-      .state('m', {
-        template: 'mState',
-        controller: function($scope) {
-          log += 'm;';
-          $scope.$on('$destroy', function() {
-            log += '$destroy(m);';
-          });
-        },
-      })
-      .state('n', {
-        template: 'nState',
-        controller: function($scope) {
-          log += 'n;';
-        },
-      })
-      .state('o', oState)
+      .state('m', mState)
   }));
 
   beforeEach(inject(function ($rootScope, _$compile_) {
@@ -159,23 +139,6 @@ describe('uiView', function () {
   }));
 
   describe('linking ui-directive', function () {
-
-    it('$destroy event is triggered after animation ends', inject(function($state, $q, $animate) {
-      elem.append($compile('<div><ui-view></ui-view></div>')(scope));
-
-      $state.transitionTo('m');
-      $q.flush();
-      expect(log).toBe('m;');
-      $state.transitionTo('n');
-      $q.flush();
-      if ($animate) {
-        expect(log).toBe('m;n;');
-        animateFlush($animate);
-        expect(log).toBe('m;n;$destroy(m);');
-      } else {
-        expect(log).toBe('m;$destroy(m);n;');
-      }
-    }));
 
     it('anonymous ui-view should be replaced with the template of the current $state', inject(function ($state, $q) {
       elem.append($compile('<div><ui-view></ui-view></div>')(scope));
@@ -362,11 +325,11 @@ describe('uiView', function () {
   }));
 
   it('should instantiate a controller with both $scope and $element injections', inject(function ($state, $q) {
-    elem.append($compile('<div><ui-view id="oState">{{elementId}}</ui-view></div>')(scope));
-    $state.transitionTo(oState);
+    elem.append($compile('<div><ui-view id="mState">{{elementId}}</ui-view></div>')(scope));
+    $state.transitionTo(mState);
     $q.flush();
 
-    expect(elem.text()).toBe('oState');
+    expect(elem.text()).toBe('mState');
   }));
 
   describe('play nicely with other directives', function() {


### PR DESCRIPTION
- Adds two promises `$animEnter`, `$animLeave` to the ui-view's element data object (`element.data('$uiView', viewData)`)
- Reverts `noanimation` workaround code from PR #2497
- Reverts the code that deferred the `scope.destroy()` until the ui-view animated out in PR #2346 