### PR TITLE
fix(transition/transitionService): uses console.error to log error in default error handler

### DIFF
--- a/src/transition/transitionService.ts
+++ b/src/transition/transitionService.ts
@@ -87,7 +87,9 @@ export class TransitionService implements ITransitionService, IHookRegistry {
   getHooks  : (hookName: string) => IEventHook[];
 
   private _defaultErrorHandler: ((_error) => void) = function $defaultErrorHandler($error$) {
-    if ($error$ instanceof Error) console.log($error$);
+    if ($error$ instanceof Error) {
+      console.error($error$);
+    }
   };
 
   defaultErrorHandler(handler: (error) => void) {


### PR DESCRIPTION
Hey,

We should use `console.error` here rather than `console.log` to benefit from the browser's error-specific logging features (e.g. stack trace display).