### PR TITLE
fix(src/resolve): use injector's strictDi value in calls to .annotate

### DIFF
--- a/src/resolve/resolvable.ts
+++ b/src/resolve/resolvable.ts
@@ -23,7 +23,12 @@ import {ResolveContext} from "./resolveContext";
  */
 export class Resolvable {
   constructor(name: string, resolveFn: Function, preResolvedData?: any) {
-    extend(this, { name, resolveFn, deps: services.$injector.annotate(resolveFn), data: preResolvedData });
+    extend(this, {
+     name, 
+     resolveFn, 
+     deps: services.$injector.annotate(resolveFn, services.$injector.strictDi), 
+     data: preResolvedData 
+   });
   }
 
   name: string;

--- a/src/resolve/resolveContext.ts
+++ b/src/resolve/resolveContext.ts
@@ -73,7 +73,7 @@ export class ResolveContext {
 
   /** Inspects a function `fn` for its dependencies.  Returns an object containing any matching Resolvables */
   getResolvablesForFn(fn: IInjectable): { [key: string]: Resolvable } {
-    let deps = services.$injector.annotate(<Function> fn);
+    let deps = services.$injector.annotate(<Function> fn, services.$injector.strictDi);
     return <any> pick(this.getResolvables(), deps);
   }
 


### PR DESCRIPTION
This PR passes through `$injector.strictDi` to `$injector.annotate` calls. At present, if a resolve function is unannotated and `$injector.strictDi` is `true`, an error is not thrown in contrast to the expected behavior for angular injectables.