### PR TITLE
Implement `resolveAs`

### DIFF
--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -289,7 +289,7 @@ export function find(collection, callback) {
 /** Given an array, returns a new array, where each element is transformed by the callback function */
 export function map<T, U>(collection: T[], callback: Mapper<T, U>): U[];
 /** Given an object, returns a new object, where each property is transformed by the callback function */
-export function map<T, U>(collection: TypedMap<T>, callback: Mapper<T, U>): TypedMap<U>;
+export function map<T, U>(collection: { [key: string]: T }, callback: Mapper<T, U>): { [key: string]: U }
 /** Maps an array or object properties using a callback function */
 export function map(collection: any, callback: any): any {
   let result = isArray(collection) ? [] : {};

--- a/src/ng1/services.ts
+++ b/src/ng1/services.ts
@@ -15,7 +15,7 @@
 /** for typedoc */
 import {UIRouter} from "../router";
 import {services} from "../common/coreservices";
-import {map, bindFunctions, removeFrom, find, noop} from "../common/common";
+import {map, bindFunctions, removeFrom, find, noop, TypedMap} from "../common/common";
 import {prop, propEq} from "../common/hof";
 import {isObject} from "../common/predicates";
 import {Node} from "../path/module";
@@ -272,7 +272,7 @@ function getTransitionsProvider() {
   loadAllControllerLocals.$inject = ['$transition$'];
   function loadAllControllerLocals($transition$) {
     const loadLocals = (vc: ViewConfig) => {
-      let resolveCtx = find($transition$.treeChanges().to, propEq('state', vc.context)).resolveContext;
+      let resolveCtx = (<Node> find($transition$.treeChanges().to, propEq('state', vc.context))).resolveContext;
       let controllerDeps = annotateController(vc.controller);
       let resolvables = resolveCtx.getResolvables();
 

--- a/src/state/hooks/resolveHooks.ts
+++ b/src/state/hooks/resolveHooks.ts
@@ -36,7 +36,7 @@ export class ResolveHooks {
       let node = find(<any[]> treeChanges.entering, propEq('state', $state$));
 
       // A new Resolvable contains all the resolved data in this context as a single object, for injection as `$resolve$`
-      let $resolve$ = new Resolvable("$resolve$", () => map(context.getResolvables(), r => r.data));
+      let $resolve$ = new Resolvable("$resolve$", () => map(context.getResolvables(), (r: Resolvable) => r.data));
       let context = node.resolveContext;
       var options = extend({transition: $transition$}, { resolvePolicy: LAZY });
 

--- a/src/state/hooks/resolveHooks.ts
+++ b/src/state/hooks/resolveHooks.ts
@@ -1,11 +1,12 @@
 /** @module state */ /** for typedoc */
-import {extend, find, tail} from "../../common/common";
+import {extend, find, tail, map} from "../../common/common";
 import {propEq} from "../../common/hof";
 
 import {ResolvePolicy} from "../../resolve/interface";
 
 import {Transition} from "../../transition/transition";
 import {val} from "../../common/hof";
+import {Resolvable} from "../../resolve/resolvable";
 
 
 let LAZY = ResolvePolicy[ResolvePolicy.LAZY];
@@ -33,7 +34,16 @@ export class ResolveHooks {
     (<any> $lazyResolveEnteringState).$inject = ['$state$', '$transition$'];
     function $lazyResolveEnteringState($state$, $transition$) {
       let node = find(<any[]> treeChanges.entering, propEq('state', $state$));
-      return node.resolveContext.resolvePathElement(node.state, extend({transition: $transition$}, { resolvePolicy: LAZY }));
+
+      // A new Resolvable contains all the resolved data in this context as a single object, for injection as `$resolve$`
+      let $resolve$ = new Resolvable("$resolve$", () => map(context.getResolvables(), r => r.data));
+      let context = node.resolveContext;
+      var options = extend({transition: $transition$}, { resolvePolicy: LAZY });
+
+      // Resolve all the LAZY resolves, then resolve the `$resolve$` object, then add `$resolve$` to the context
+      return context.resolvePathElement(node.state, options)
+          .then(() => $resolve$.resolveResolvable(context))
+          .then(() => context.addResolvables({$resolve$}, node.state));
     }
 
     // Resolve eager resolvables before when the transition starts

--- a/src/state/interface.ts
+++ b/src/state/interface.ts
@@ -79,6 +79,19 @@ export interface ViewDeclaration {
   controllerProvider?:  Function;
 
   /**
+   * The scope variable name to use for resolve data.
+   *
+   * A property of either [[StateDeclaration]] or [[ViewDeclaration]].  For a given view, the view-level property
+   * takes precedence over the state-level property.
+   *
+   * When a view is activated, the resolved data for the state which the view belongs to is put on the scope.
+   * This property sets the name of the scope variable to use for the resolved data.
+   *
+   * Defaults to `$resolve`.
+   */
+  resolveAs?: string;
+
+  /**
    * A property of [[StateDeclaration]] or [[ViewDeclaration]]:
    *
    * HTML template as a string or a function which returns an html template as a string.

--- a/src/state/stateBuilder.ts
+++ b/src/state/stateBuilder.ts
@@ -102,7 +102,7 @@ export class StateBuilder {
       views: [function (state: State) {
         let views = {},
             tplKeys = ['templateProvider', 'templateUrl', 'template', 'notify', 'async'],
-            ctrlKeys = ['controller', 'controllerProvider', 'controllerAs'];
+            ctrlKeys = ['controller', 'controllerProvider', 'controllerAs', 'resolveAs'];
         let allKeys = tplKeys.concat(ctrlKeys);
 
         forEach(state.views || {"$default": pick(state, allKeys)}, function (config, name) {
@@ -111,7 +111,8 @@ export class StateBuilder {
           forEach(ctrlKeys, (key) => {
             if (state[key] && !config[key]) config[key] = state[key];
           });
-          if (Object.keys(config).length > 0) views[name] = config;
+          config.resolveAs = config.resolveAs || '$resolve';
+          if (Object.keys(config).length > 1) views[name] = config;
         });
         return views;
       }],

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -54,6 +54,7 @@ export class ViewConfig {
   template: string;
   controller: Function;
   controllerAs: string;
+  resolveAs: string;
 
   context: ViewContext;
 
@@ -78,6 +79,7 @@ export class ViewConfig {
 
     extend(this, pick(stateViewConfig, "viewDeclarationObj", "params", "context", "locals", "node"), {uiViewName, uiViewContextAnchor});
     this.controllerAs = stateViewConfig.viewDeclarationObj.controllerAs;
+    this.resolveAs = stateViewConfig.viewDeclarationObj.resolveAs;
   }
 
   /**

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -181,7 +181,7 @@ describe('state helpers', function() {
       it('should return filtered keys if view config is provided', function() {
         var config = { url: "/foo", templateUrl: "/foo.html", controller: "FooController" };
         expect(builder.builder('views')(config)).toEqual({
-          $default: { templateUrl: "/foo.html", controller: "FooController" }
+          $default: { templateUrl: "/foo.html", controller: "FooController", resolveAs: '$resolve' }
         });
       });
 


### PR DESCRIPTION
Add a new injectable `$resolve$` for each node.  `$resolve$` contains the resolved data available for injection in that node.

Implement `scope.$resolve` support like ngRoute.  Allows routing to components using a template like 
```
.state('foo', {
  template: '<user-component user="$resolve.user"></user-component>',
  resolve: { user: UserService => UserService.getUser(); }
});
```