### PR TITLE
refactor(view): refactor how views are loaded and configured.

### DIFF
--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -499,9 +499,8 @@ export function padString(length: number, str: string) {
   return str;
 }
 
-export function tail<T>(collection: T[]): T;
 /** Get the last element of an array */
-export function tail(arr: any[]): any {
+export function tail<T>(arr: T[]): T {
   return arr.length && arr[arr.length - 1] || undefined;
 }
 

--- a/src/ng1.ts
+++ b/src/ng1.ts
@@ -12,5 +12,6 @@ export * from "./ng1/stateDirectives";
 export * from "./ng1/stateFilters";
 export * from "./ng1/viewDirective";
 export * from "./ng1/viewScroll";
+export * from "./ng1/viewsBuilder";
 
 export default "ui.router";

--- a/src/ng1/stateDirectives.ts
+++ b/src/ng1/stateDirectives.ts
@@ -1,8 +1,8 @@
 /** @module state */ /** for typedoc */
 /// <reference path='../../typings/angularjs/angular.d.ts' />
-import {extend, copy, defaults, forEach, toJson} from "../common/common";
+import {extend, forEach, toJson} from "../common/common";
 import {isString, isObject} from "../common/predicates";
-import {defaultTransOpts} from "../transition/module";
+import {UIViewData} from "./viewDirective";
 
 function parseStateRef(ref, current) {
   let preparsed = ref.match(/^\s*({[^}]*})\s*$/), parsed;
@@ -13,10 +13,10 @@ function parseStateRef(ref, current) {
 }
 
 function stateContext(el) {
-  let stateData = el.parent().inheritedData('$uiView');
+  let $uiView: UIViewData = el.parent().inheritedData('$uiView');
 
-  if (stateData && stateData.context && stateData.context.name) {
-    return stateData.context;
+  if ($uiView && $uiView.$cfg.context && $uiView.$cfg.context.name) {
+    return $uiView.$cfg.context;
   }
 }
 

--- a/src/ng1/viewsBuilder.ts
+++ b/src/ng1/viewsBuilder.ts
@@ -1,0 +1,107 @@
+/** @module ng1 */ /** */
+import {State} from "../state/stateObject";
+import {pick, forEach} from "../common/common";
+import {ViewConfig, ViewContext} from "../view/interface";
+import {Ng1ViewDeclaration} from "./interface";
+import {ViewService} from "../view/view";
+import {isInjectable} from "../common/predicates";
+import {services} from "../common/coreservices";
+import {trace} from "../common/trace";
+import {Node} from "../path/node";
+import {TemplateFactory} from "../view/templateFactory";
+import {ResolveContext} from "../resolve/resolveContext";
+
+export const ng1ViewConfigFactory = (node, view) => new Ng1ViewConfig(node, view);
+
+/**
+ * This is a [[StateBuilder.builder]] function for angular1 `views`.
+ *
+ * When the [[StateBuilder]] builds a [[State]] object from a raw [[StateDeclaration]], this builder
+ * handles the `views` property with logic specific to angular-ui-router (ng1).
+ *
+ * If no `views: {}` property exists on the [[StateDeclaration]], then it creates the `views` object
+ * and applies the state-level configuration to a view named `$default`.
+ */
+export function ng1ViewsBuilder(state: State) {
+  let tplKeys = ['templateProvider', 'templateUrl', 'template', 'notify', 'async'],
+      ctrlKeys = ['component', 'controller', 'controllerProvider', 'controllerAs', 'resolveAs'],
+      allKeys = tplKeys.concat(ctrlKeys);
+
+  let views = {}, viewsObject = state.views || {"$default": pick(state, allKeys)};
+
+  forEach(viewsObject, function (config: Ng1ViewDeclaration, name) {
+    name = name || "$default"; // Account for views: { "": { template... } }
+    // Allow controller settings to be defined at the state level for all views
+    forEach(ctrlKeys, (key) => {
+      if (state[key] && !config[key]) config[key] = state[key];
+    });
+    if (!Object.keys(config).length) return;
+
+    config.resolveAs = config.resolveAs || '$resolve';
+    config.$type = "ng1";
+    config.$context = state;
+    config.$name = name;
+
+    let normalized = ViewService.normalizeUiViewTarget(config.$context, config.$name);
+    config.$uiViewName = normalized.uiViewName;
+    config.$uiViewContextAnchor = normalized.uiViewContextAnchor;
+
+    views[name] = config;
+  });
+  return views;
+}
+
+export class Ng1ViewConfig implements ViewConfig {
+  loaded: boolean = false;
+  controller: Function;
+  template: string;
+  locals: any; // TODO: delete me
+
+  constructor(public node: Node, public viewDecl: Ng1ViewDeclaration) { }
+  get context(): ViewContext { return this.viewDecl.$context; }
+  get controllerAs() { return this.viewDecl.controllerAs; }
+  get resolveAs() { return this.viewDecl.resolveAs; }
+
+  load() {
+    let $q = services.$q;
+    if (!this.hasTemplate())
+      throw new Error(`No template configuration specified for '${this.viewDecl.$uiViewName}@${this.viewDecl.$uiViewContextAnchor}'`);
+
+    let injector = this.node.resolveContext;
+    let params = this.node.paramValues;
+    let promises: any = {
+      template: $q.when(this.getTemplate(params, new TemplateFactory(), injector)),
+      controller: $q.when(this.getController(injector))
+    };
+
+    return $q.all(promises).then((results) => {
+      trace.traceViewServiceEvent("Loaded", this);
+      this.controller = results.controller;
+      this.template = results.template;
+    });
+  }
+
+  /**
+   * Checks a view configuration to ensure that it specifies a template.
+   *
+   * @return {boolean} Returns `true` if the configuration contains a valid template, otherwise `false`.
+   */
+  hasTemplate() {
+    return !!(this.viewDecl.template || this.viewDecl.templateUrl || this.viewDecl.templateProvider);
+  }
+
+  getTemplate(params, $factory, injector: ResolveContext) {
+    return $factory.fromConfig(this.viewDecl, params, injector.invokeLater.bind(injector));
+  }
+
+  /**
+   * Gets the controller for a view configuration.
+   *
+   * @returns {Function|Promise.<Function>} Returns a controller, or a promise that resolves to a controller.
+   */
+  getController(injector: ResolveContext) {
+    //* @param {Object} locals A context object from transition.context() to invoke a function in the correct context
+    let provider = this.viewDecl.controllerProvider;
+    return isInjectable(provider) ? injector.invokeLater(provider, {}) : this.viewDecl.controller;
+  }
+}

--- a/src/ng2/interface.ts
+++ b/src/ng2/interface.ts
@@ -1,0 +1,7 @@
+/** @module ng2 */ /** */
+import {_ViewDeclaration} from "../state/interface";
+import {Type} from "angular2/core";
+
+export interface Ng2ViewDeclaration extends _ViewDeclaration {
+  component: Type;
+}

--- a/src/ng2/viewsBuilder.ts
+++ b/src/ng2/viewsBuilder.ts
@@ -1,0 +1,21 @@
+import {State} from "../state/stateObject";
+import {pick, forEach} from "../common/common";
+
+/**
+ * This is a [[StateBuilder.builder]] function for angular2 `views`.
+ *
+ * When the [[StateBuilder]] builds a [[State]] object from a raw [[StateDeclaration]], this builder
+ * handles the `views` property with logic specific to ui-router-ng2.
+ *
+ * If no `views: {}` property exists on the [[StateDeclaration]], then it creates the `views` object and
+ * applies the state-level configuration to a view named `$default`.
+ */
+export function ng2ViewsBuilder(state: State) {
+  let views = {}, viewsObject = state.views || {"$default": pick(state, "component")};
+
+  forEach(viewsObject, function (config, name) {
+    name = name || "$default"; // Account for views: { "": { template... } }
+    if (Object.keys(config).length > 1) views[name] = config;
+  });
+  return views;
+}

--- a/src/path/node.ts
+++ b/src/path/node.ts
@@ -5,30 +5,27 @@ import {State} from "../state/module";
 import {RawParams} from "../params/interface";
 import {Param} from "../params/module";
 import {Resolvable, ResolveContext, ResolveInjector} from "../resolve/module";
-import {ViewConfig} from "../view/view";
+import {ViewConfig} from "../view/interface";
+
+export type Resolvables = { [key: string]: Resolvable };
 
 export class Node {
-
-  public paramSchema:   Param[];
-  public paramValues:   { [key: string]: any };
-  public resolves: any;
-  public views:    ViewConfig[];
+  public paramSchema: Param[];
+  public paramValues: { [key: string]: any };
+  public resolves: Resolvables;
+  public views: ViewConfig[];
   public resolveContext: ResolveContext;
   public resolveInjector: ResolveInjector;
 
   // Possibly extract this logic into an intermediary object that maps states to nodes
-  constructor(public state: State, params: RawParams = {}, resolves: any = {}) {
+  constructor(public state: State, params: RawParams = {}, resolvables: Resolvables = {}) {
     // Object.freeze(extend(this, { ... }))
     this.paramSchema = state.parameters({ inherit: false });
 
     const getParamVal = (paramDef: Param) => [ paramDef.id, paramDef.value(params[paramDef.id]) ];
     this.paramValues = this.paramSchema.reduce((memo, pDef) => applyPairs(memo, getParamVal(pDef)), {});
 
-    this.resolves = extend(map(state.resolve, (fn: Function, name: string) => new Resolvable(name, fn)), resolves);
-
-    const makeViewConfig = (viewDeclarationObj, rawViewName) =>
-        new ViewConfig({ rawViewName, viewDeclarationObj, context: state, params, node: this});
-    this.views = values(map(state.views, makeViewConfig));
+    this.resolves = extend(map(state.resolve, (fn: Function, name: string) => new Resolvable(name, fn)), resolvables);
   }
 
   parameter(name: string): Param {

--- a/src/resolve/resolveContext.ts
+++ b/src/resolve/resolveContext.ts
@@ -10,6 +10,7 @@ import {Node} from "../path/module";
 import {Resolvable} from "./resolvable";
 import {State} from "../state/module";
 import {mergeR} from "../common/common";
+import {PathFactory} from "../path/pathFactory";
 
 // TODO: make this configurable
 let defaultResolvePolicy = ResolvePolicy[ResolvePolicy.LAZY];
@@ -28,10 +29,7 @@ export class ResolveContext {
         return <Node> find(this._path, propEq('state', state));
       },
       _pathTo(state: State): Node[] {
-        let node = this._nodeFor(state);
-        let elementIdx = this._path.indexOf(node);
-        if (elementIdx === -1) throw new Error("This path does not contain the state");
-        return this._path.slice(0, elementIdx + 1);
+        return PathFactory.subPath(this._path, state);
       }
     });
   }

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,8 +1,7 @@
 import {UrlMatcherFactory} from "./url/urlMatcherFactory";
 import {UrlRouterProvider} from "./url/urlRouter";
 import {StateProvider} from "./state/state";
-import {stateParamsFactory} from "./params/stateParams";
-import {StateParams} from "./params/stateParams";
+import {stateParamsFactory, StateParams} from "./params/stateParams";
 import {UrlRouter} from "./url/urlRouter";
 import {TransitionService} from "./transition/transitionService";
 import {TemplateFactory} from "./view/templateFactory";
@@ -21,7 +20,7 @@ import {StateService} from "./state/stateService";
  */
 export class UIRouter {
 
-  stateParams = stateParamsFactory();
+  stateParams: StateParams = stateParamsFactory();
 
   urlMatcherFactory: UrlMatcherFactory = new UrlMatcherFactory();
 
@@ -29,11 +28,11 @@ export class UIRouter {
 
   urlRouter: UrlRouter = new UrlRouter(this.urlRouterProvider);
 
-  transitionService: TransitionService = new TransitionService();
-
   templateFactory = new TemplateFactory();
 
-  viewService = new ViewService(this.templateFactory);
+  viewService = new ViewService();
+
+  transitionService: TransitionService = new TransitionService(this.viewService);
 
   stateRegistry: StateRegistry = new StateRegistry(this.urlMatcherFactory, this.urlRouterProvider);
 

--- a/src/state/hooks/viewHooks.ts
+++ b/src/state/hooks/viewHooks.ts
@@ -1,13 +1,12 @@
 /** @module state */ /** for typedoc */
-import {find, noop} from "../../common/common";
-import {propEq} from "../../common/hof";
+import {noop} from "../../common/common";
 import {services} from "../../common/coreservices";
 
 import {TreeChanges} from "../../transition/interface";
 import {Transition} from "../../transition/transition";
 
-import {ViewConfig} from "../../view/view";
 import {ViewService} from "../../view/view";
+import {ViewConfig} from "../../view/interface";
 
 export class ViewHooks {
   private treeChanges: TreeChanges;
@@ -26,17 +25,13 @@ export class ViewHooks {
   }
 
   loadAllEnteringViews() {
-    const loadView = (vc: ViewConfig) => {
-      let resolveInjector = find(this.treeChanges.to, propEq('state', vc.context)).resolveInjector;
-      return <Promise<ViewConfig>> this.$view.load(vc, resolveInjector);
-    };
-    return services.$q.all(this.enteringViews.map(loadView)).then(noop);
+    return services.$q.all(this.enteringViews.map(view => view.load())).then(noop);
   }
 
   updateViews() {
     let $view = this.$view;
-    this.exitingViews.forEach((viewConfig: ViewConfig) => $view.reset(viewConfig));
-    this.enteringViews.forEach((viewConfig: ViewConfig) => $view.registerStateViewConfig(viewConfig));
+    this.exitingViews.forEach((viewConfig: ViewConfig) => $view.deactivateViewConfig(viewConfig));
+    this.enteringViews.forEach((viewConfig: ViewConfig) => $view.activateViewConfig(viewConfig));
     $view.sync();
   }
 

--- a/src/state/stateBuilder.ts
+++ b/src/state/stateBuilder.ts
@@ -94,28 +94,9 @@ export class StateBuilder {
         return urlParams.concat(nonUrlParams).map(p => [p.id, p]).reduce(applyPairs, {});
       }],
 
-      // If there is no explicit multi-view configuration, make one up so we don't have
-      // to handle both cases in the view directive later. Note that having an explicit
-      // 'views' property will mean the default unnamed view properties are ignored. This
-      // is also a good time to resolve view names to absolute names, so everything is a
-      // straight lookup at link time.
-      views: [function (state: State) {
-        let views = {},
-            tplKeys = ['templateProvider', 'templateUrl', 'template', 'notify', 'async'],
-            ctrlKeys = ['controller', 'controllerProvider', 'controllerAs', 'resolveAs'];
-        let allKeys = tplKeys.concat(ctrlKeys);
-
-        forEach(state.views || {"$default": pick(state, allKeys)}, function (config, name) {
-          name = name || "$default"; // Account for views: { "": { template... } }
-          // Allow controller settings to be defined at the state level for all views
-          forEach(ctrlKeys, (key) => {
-            if (state[key] && !config[key]) config[key] = state[key];
-          });
-          config.resolveAs = config.resolveAs || '$resolve';
-          if (Object.keys(config).length > 1) views[name] = config;
-        });
-        return views;
-      }],
+      // Each framework-specific ui-router implementation should define its own `views` builder
+      // e.g., src/ng1/viewsBuilder.ts
+      views: [],
 
       // Keep a full path from the root down to this state as this is needed for state activation.
       path: [function (state: State) {

--- a/src/state/stateObject.ts
+++ b/src/state/stateObject.ts
@@ -1,6 +1,6 @@
 /** @module state */ /** for typedoc */
 
-import {StateDeclaration, ViewDeclaration} from "./interface";
+import {StateDeclaration, _ViewDeclaration} from "./interface";
 import {extend, defaults, values, find} from "../common/common";
 import {propEq} from "../common/hof";
 import {Param} from "../params/module";
@@ -27,7 +27,7 @@ export class State {
   public resolvePolicy: any;
   public url: UrlMatcher;
   public params: { [key: string]: Param };
-  public views: { [key: string]: ViewDeclaration; };
+  public views: { [key: string]: _ViewDeclaration; };
   public self: StateDeclaration;
   public navigable: State;
   public path: State[];

--- a/src/state/stateRegistry.ts
+++ b/src/state/stateRegistry.ts
@@ -46,7 +46,7 @@ export class StateRegistry {
 
   get(): StateDeclaration[];
   get(stateOrName: StateOrName, base: StateOrName): StateDeclaration;
-  get(stateOrName?: StateOrName, base?: StateOrName): (StateDeclaration|StateDeclaration[]) {
+  get(stateOrName?: StateOrName, base?: StateOrName): any {
     if (arguments.length === 0) 
       return <StateDeclaration[]> Object.keys(this.states).map(name => this.states[name].self);
     let found = this.matcher.find(stateOrName, base);

--- a/src/transition/transitionService.ts
+++ b/src/transition/transitionService.ts
@@ -6,6 +6,7 @@ import {HookRegistry} from "./hookRegistry";
 import {TargetState} from "../state/module";
 import {Node} from "../path/module";
 import {IEventHook} from "./interface";
+import {ViewService} from "../view/view";
 
 /**
  * The default transition options.
@@ -30,7 +31,7 @@ export let defaultTransOpts: TransitionOptions = {
  * for creating new Transitions.
  */
 export class TransitionService implements ITransitionService, IHookRegistry {
-  constructor() {
+  constructor(public $view: ViewService) {
     HookRegistry.mixin(new HookRegistry(), this);
   }
 

--- a/src/view/interface.ts
+++ b/src/view/interface.ts
@@ -1,19 +1,48 @@
 /** @module view */ /** for typedoc */
-import {ViewConfig} from "./module";
+import {_ViewDeclaration} from "../state/interface";
+import {Node} from "../path/node";
 
-/** The context ref can be anything that has a `name` and a `parent` reference to another IContextRef */
+/**
+ * The context ref can be anything that has a `name` and a `parent` reference to another IContextRef
+ */
 export interface ViewContext {
   name: string;
   parent: ViewContext;
 }
 
 /** @hidden */
-export interface UIViewData {
+export interface ActiveUIView {
   id: number;
   name: string;
   fqn: string;
-  config: any;
+  config: ViewConfig;
   // The context in which the ui-view tag was created.
   creationContext: ViewContext;
   configUpdated: (config: ViewConfig) => void;
+}
+
+/**
+ * This interface represents a [[ViewDeclaration]] that is bound to a [[Node]].
+ *
+ * A `ViewConfig` is the runtime definition of a single view.
+ *
+ * During a transition, `ViewConfig`s are created for each [[ViewDeclaration]] defined on each "entering" [[State]].
+ * Then, the [[ViewService]] finds any matching `ui-view`(s) in the DOM, and supplies the ui-view
+ * with the `ViewConfig`.  The `ui-view` then loads itself using the information found in the `ViewConfig`.
+ *
+ * A `ViewConfig` if matched with a `ui-view` by finding all `ui-view`s which were created in the
+ * context named by the `uiViewContextAnchor`, and finding the `ui-view` or child `ui-view` that matches
+ * the `uiViewName` address.
+ */
+export interface ViewConfig {
+  /** The normalized view declaration from [[State.views]] */
+  viewDecl: _ViewDeclaration;
+
+  /** The node the ViewConfig is bound to */
+  node: Node;
+
+  /** Fetches templates, runs dynamic (controller|template)Provider code, lazy loads Components, etc */
+  load(): Promise<ViewConfig>;
+  
+  loaded: boolean;
 }

--- a/src/view/templateFactory.ts
+++ b/src/view/templateFactory.ts
@@ -1,7 +1,7 @@
 /** @module view */ /** for typedoc */
 import {isDefined, isFunction} from "../common/predicates";
 import {services} from "../common/coreservices";
-import {ViewDeclaration} from "../state/interface";
+import {Ng1ViewDeclaration} from "../ng1/interface";
 
 /**
  * Service which manages loading of templates from a ViewConfig.
@@ -21,7 +21,7 @@ export class TemplateFactory {
    * @return {string|object}  The template html as a string, or a promise for 
    * that string,or `null` if no template is configured.
    */
-  fromConfig(config: ViewDeclaration, params: any, injectFn: Function) {
+  fromConfig(config: Ng1ViewDeclaration, params: any, injectFn: Function) {
     return (
       isDefined(config.template) ? this.fromString(config.template, params) :
       isDefined(config.templateUrl) ? this.fromUrl(config.templateUrl, params) :

--- a/test/resolveSpec.ts
+++ b/test/resolveSpec.ts
@@ -127,7 +127,7 @@ describe('Resolvables system:', function () {
           makePath([ "P" ]);
         }).toThrowError(/strictdi/);
       }
-    });
+    }));
 
     it('should not throw when creating a resolvable with an annotated fn and strictDi mode on', inject(function ($injector) {
       if (supportsStrictDi) {
@@ -135,7 +135,7 @@ describe('Resolvables system:', function () {
           makePath([ "PAnnotated" ]);
         }).not.toThrowError(/strictdi/);
       }
-    });
+    }));
   });
 
   describe('ResolveContext.resolvePathElement()', function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,10 @@
     "declaration": true,
     "sourceMap": true
   },
-  "files": [
-    "src/ng1.ts",
-    "src/ng1/stateEvents.ts"
+  "exclude": [
+    "node_modules",
+    "build",
+    "build_packages",
+    "test"
   ]
 }


### PR DESCRIPTION
- Each framework (ng1/ng2) to provide a `StateBuilder` `views` decorator that understand different keys/values to meet that framework's needs
  - The `views` decorator takes `ViewDeclaration`s (the `views` block on the state declaration), and processes them.  It returns normalized framework specific POJOs (i.e. `Ng1ViewDeclaration`s)
- Before a `Transition` begins, each normalized `ViewDeclaration` being activated is converted into a `ViewConfig` and added to the `Node`'s `views` array
  - The `ViewService` is responsible for creating an instance of a `ViewConfig` from the `ViewDeclaration`, based on the type of `ViewDeclaration` (registered using `ViewService.viewConfigFactory`)
  - Each ViewConfig is bound to the appropriate Node in the "to path"
- During the transition, the `ViewConfig` is prepped (load templates, controllers, components) using `viewConfig.load()`
- After the configs are prepped, they are registered with the `StateService` (to be matched with `ui-view`s)
- The `$element.data('$uiView')` is reorganized and simplified.
  - $element.data('$uiView').$uiView has the `ActiveUIView` ref object (formerly named `UiViewData`)
  - $element.data('$uiView').$cfg has the activated `ViewConfig` ref object

