### PR TITLE
[WIP] fix: $stateChangeStart with event.preventDefault()

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -974,7 +974,10 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
       
       // Stop transition when prevented
       if($rootScope.$broadcast('$stateChangeStart', to.self, toParams, from.self, fromParams, options).defaultPrevented){
-          return TransitionPrevented;
+        $rootScope.$broadcast('$stateChangeCancel', to.self, toParams, from.self, fromParams);
+        //Don't update and resync url if there's been a new transition started. see issue #2238, #600
+        if ($state.transition == null) $urlRouter.update();
+        return TransitionPrevented;
       }
 
       // Store the hash param for later (since it will be stripped out by various methods)

--- a/src/state.js
+++ b/src/state.js
@@ -964,6 +964,11 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
      * {@link ui.router.state.$state#methods_go $state.go}.
      */
     $state.transitionTo = function transitionTo(to, toParams, options) {
+      // Stop transition when prevented
+      if($rootScope.$broadcast('$stateChangeStart', to.self, toParams, from.self, fromParams, options).defaultPrevented){
+          return TransitionPrevented;
+      }
+      
       toParams = toParams || {};
       options = extend({
         location: true, inherit: false, relative: null, notify: true, reload: false, $retry: false

--- a/src/state.js
+++ b/src/state.js
@@ -964,11 +964,6 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
      * {@link ui.router.state.$state#methods_go $state.go}.
      */
     $state.transitionTo = function transitionTo(to, toParams, options) {
-      // Stop transition when prevented
-      if($rootScope.$broadcast('$stateChangeStart', to.self, toParams, from.self, fromParams, options).defaultPrevented){
-          return TransitionPrevented;
-      }
-      
       toParams = toParams || {};
       options = extend({
         location: true, inherit: false, relative: null, notify: true, reload: false, $retry: false
@@ -976,6 +971,11 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
 
       var from = $state.$current, fromParams = $state.params, fromPath = from.path;
       var evt, toState = findState(to, options.relative);
+      
+      // Stop transition when prevented
+      if($rootScope.$broadcast('$stateChangeStart', to.self, toParams, from.self, fromParams, options).defaultPrevented){
+          return TransitionPrevented;
+      }
 
       // Store the hash param for later (since it will be stripped out by various methods)
       var hash = toParams['#'];


### PR DESCRIPTION
In order to properly process preventing event handling in libs like angular-permission earlier breaking of transitionTo is required to avoid doubled state resolving and allow async calls combined with access to states. 