### PR TITLE
fix(uiSref, uiState): added click unbind to prevent memory leaks

### DIFF
--- a/src/stateDirectives.js
+++ b/src/stateDirectives.js
@@ -124,6 +124,7 @@ function $StateRefDirective($state, $timeout) {
       var type   = getTypeInfo(element);
       var active = uiSrefActive[1] || uiSrefActive[0];
       var unlinkInfoFn = null;
+      var hookFn;
 
       def.options = extend(defaultOpts(element, $state), attrs.uiSrefOpts ? scope.$eval(attrs.uiSrefOpts) : {});
 
@@ -143,7 +144,11 @@ function $StateRefDirective($state, $timeout) {
       update();
 
       if (!type.clickable) return;
-      element.bind("click", clickHook(element, $state, $timeout, type, function() { return def; }));
+      hookFn = clickHook(element, $state, $timeout, type, function() { return def; });
+      element.bind("click", hookFn);
+      scope.$on('$destroy', function() {
+        element.unbind("click", hookFn);
+      });
     }
   };
 }
@@ -176,6 +181,7 @@ function $StateRefDynamicDirective($state, $timeout) {
       var watch  = '[' + group.map(function(val) { return val || 'null'; }).join(', ') + ']';
       var def    = { state: null, params: null, options: null, href: null };
       var unlinkInfoFn = null;
+      var hookFn;
 
       function runStateRefLink (group) {
         def.state = group[0]; def.params = group[1]; def.options = group[2];
@@ -190,7 +196,11 @@ function $StateRefDynamicDirective($state, $timeout) {
       runStateRefLink(scope.$eval(watch));
 
       if (!type.clickable) return;
-      element.bind("click", clickHook(element, $state, $timeout, type, function() { return def; }));
+      hookFn = clickHook(element, $state, $timeout, type, function() { return def; });
+      element.bind("click", hookFn);
+      scope.$on('$destroy', function() {
+        element.unbind("click", hookFn);
+      });
     }
   };
 }


### PR DESCRIPTION
Fixed memory leaks beetween states with many ui-sref in their templates