### PR TITLE
refactor(uiView): just promisify animation and simplify some code

### DIFF
--- a/test/viewDirectiveSpec.js
+++ b/test/viewDirectiveSpec.js
@@ -288,6 +288,7 @@ describe('uiView', function () {
       $q.flush();
 
       animateFlush($animate);
+      $q.flush();
 
       expect($uiViewScroll).toHaveBeenCalledWith(elem.find('span').parent());
     }));
@@ -309,6 +310,7 @@ describe('uiView', function () {
       $q.flush();
 
       animateFlush($animate);
+      $q.flush();
 
       var target,
           index   = -1,


### PR DESCRIPTION
`$q.defer()` is used for capability, cause older versions of angular is not supported `$q(function(resolve) {...})` and `$q.resolve()`
