### PR TITLE
ng2 - Enable change detection for route components

### DIFF
--- a/src/ng2/uiView.ts
+++ b/src/ng2/uiView.ts
@@ -175,6 +175,9 @@ export class UiView {
       inputs.map(tuple => ({ prop: tuple.prop, resolve: bindings[tuple.prop] || tuple.resolve }))
           .filter(tuple => resolvables[tuple.resolve] !== undefined)
           .forEach(tuple => { ref.instance[tuple.prop] = resolvables[tuple.resolve].data });
+          
+      // Initiate change detection for the newly created component
+      ref.changeDetectorRef.detectChanges();
     };
 
     this.compResolver.resolveComponent(componentType).then(createComponent);


### PR DESCRIPTION
Newly created components need an initial change detection to be fired manually.

Perhaps this is only a problem when the components are using the OnPush ChangeDetectionStrategy.  Without this fix, components don't load data until some browser event fires - i.e. click, etc.