### PR TITLE
Made ui-router noImplicitAny compliant

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,7 @@ module.exports = function (grunt) {
         files: {
           '<%= builddir %>/ui-router-ng2.min.js': ['<banner:meta.banner>', '<%= builddir %>/ui-router-ng2.js'],
           '<%= builddir %>/angular-ui-router.min.js': ['<banner:meta.banner>', '<%= builddir %>/angular-ui-router.js'],
-          '<%= builddir %>/ng1/stateEvents.min.js': ['<banner:meta.banner>', '<%= builddir %>/ng1/stateEvents.js']
+          '<%= builddir %>/ng1/legacy/stateEvents.min.js': ['<banner:meta.banner>', '<%= builddir %>/ng1/legacy/stateEvents.js']
         }
       }
     },
@@ -180,7 +180,7 @@ module.exports = function (grunt) {
     grunt.task.run(['webpack']);
 
     ['stateEvents.js', 'stateEvents.js.map'].forEach(function(file) {
-      grunt.file.copy(builddir + "/es5/ng1/" + file, builddir + "/ng1/" + file);
+      grunt.file.copy(builddir + "/es5/ng1/legacy/" + file, builddir + "/ng1/legacy/" + file);
     })
   });
 

--- a/files.js
+++ b/files.js
@@ -6,7 +6,7 @@ routerFiles = {
 
   src:                [
     'src/ng1.ts', // UI-Router angular1 module (re-exports ui-router and ng1 modules)
-    'src/ng1/stateEvents.ts' // There might be a better approach to compiling this file
+    'src/ng1/legacy/stateEvents.ts' // There might be a better approach to compiling this file
     //'src/ui-router.ts', // Main UI-Router module (re-exports all other core modules)
     //'src/ng2.ts', // UI-Router angular2 module (re-exports ui-router and ng2 modules)
     //'src/justjs.ts', // UI-Router plain ol js module (re-exports ui-router)

--- a/src/common/common.ts
+++ b/src/common/common.ts
@@ -15,12 +15,12 @@ export const copy = angular.copy || _copy;
 export const forEach = angular.forEach || _forEach;
 export const extend = angular.extend || _extend;
 export const equals = angular.equals || _equals;
-export const identity = (x) => x;
-export const noop = () => undefined;
+export const identity = (x: any) => x;
+export const noop = () => undefined as any;
 
 export type Mapper<X, T> = (x: X, key?: (string|number)) => T;
 export interface TypedMap<T> { [key: string]: T; }
-export type Predicate<X> = (X) => boolean;
+export type Predicate<X> = (X: any) => boolean;
 export type IInjectable = (Function|any[]);
 
 export var abstractKey = 'abstract';
@@ -80,7 +80,7 @@ export var abstractKey = 'abstract';
  * @param bindTo The object which the functions will be bound to
  * @param fnNames The function names which will be bound (Defaults to all the functions found on the 'from' object)
  */
-export function bindFunctions(from, to, bindTo, fnNames: string[] = Object.keys(from)) {
+export function bindFunctions(from: any, to: any, bindTo: any, fnNames: string[] = Object.keys(from)) {
   return fnNames.filter(name => typeof from[name] === 'function')
       .forEach(name => to[name] = from[name].bind(bindTo));
 }
@@ -90,7 +90,7 @@ export function bindFunctions(from, to, bindTo, fnNames: string[] = Object.keys(
  * prototypal inheritance helper.
  * Creates a new object which has `parent` object as its prototype, and then copies the properties from `extra` onto it
  */
-export const inherit = (parent, extra) =>
+export const inherit = (parent: any, extra: any) =>
     extend(new (extend(function() {}, { prototype: parent }))(), extra);
 
 /**
@@ -116,13 +116,13 @@ export const inherit = (parent, extra) =>
  *        pick(obj, "foo", "bar");   // returns { foo: 1, bar: 2 }
  *        pick(obj, ["foo", "bar"]); // returns { foo: 1, bar: 2 }
  */
-const restArgs = (args, idx = 0) => Array.prototype.concat.apply(Array.prototype, Array.prototype.slice.call(args, idx));
+const restArgs = (args: any, idx = 0) => Array.prototype.concat.apply(Array.prototype, Array.prototype.slice.call(args, idx));
 
 /** Given an array, returns true if the object is found in the array, (using indexOf) */
 export const inArray = (array: any[], obj: any) => array.indexOf(obj) !== -1;
 
 /** Given an array, and an item, if the item is found in the array, it removes it (in-place).  The same array is returned */
-export const removeFrom = curry((array: any[], obj) => {
+export const removeFrom = curry((array: any[], obj: any) => {
   let idx = array.indexOf(obj);
   if (idx >= 0) array.splice(idx, 1);
   return array;
@@ -133,7 +133,7 @@ export const removeFrom = curry((array: any[], obj) => {
  * to only those properties of the objects in the defaultsList.
  * Earlier objects in the defaultsList take precedence when applying defaults.
  */
-export function defaults(opts = {}, ...defaultsList) {
+export function defaults(opts = {}, ...defaultsList: any[]) {
   let defaults = merge.apply(null, [{}].concat(defaultsList));
   return extend({}, defaults, pick(opts || {}, Object.keys(defaults)));
 }
@@ -142,9 +142,9 @@ export function defaults(opts = {}, ...defaultsList) {
  * Merges properties from the list of objects to the destination object.
  * If a property already exists in the destination object, then it is not overwritten.
  */
-export function merge(dst, ...objs: Object[]) {
-  forEach(objs, function(obj) {
-    forEach(obj, function(value, key) {
+export function merge(dst: any, ...objs: Object[]) {
+  forEach(objs, function(obj: any) {
+    forEach(obj, function(value: any, key: any) {
       if (!dst.hasOwnProperty(key)) dst[key] = value;
     });
   });
@@ -152,7 +152,7 @@ export function merge(dst, ...objs: Object[]) {
 }
 
 /** Reduce function that merges each element of the list into a single object, using extend */
-export const mergeR = (memo, item) => extend(memo, item);
+export const mergeR = (memo: any, item: any) => extend(memo, item);
 
 /**
  * Finds the common ancestor path between two states.
@@ -161,8 +161,8 @@ export const mergeR = (memo, item) => extend(memo, item);
  * @param {Object} second The second state.
  * @return {Array} Returns an array of state names in descending order, not including the root.
  */
-export function ancestors(first, second) {
-  let path = [];
+export function ancestors(first: any, second: any) {
+  let path: any[] = [];
 
   for (var n in first.path) {
     if (first.path[n] !== second.path[n]) break;
@@ -180,7 +180,7 @@ export function ancestors(first, second) {
  *                     it defaults to the list of keys in `a`.
  * @return {Boolean} Returns `true` if the keys match, otherwise `false`.
  */
-export function equalForKeys(a, b, keys: string[] = Object.keys(a)) {
+export function equalForKeys(a: any, b: any, keys: string[] = Object.keys(a)) {
   for (var i = 0; i < keys.length; i++) {
     let k = keys[i];
     if (a[k] != b[k]) return false; // Not '===', values aren't necessarily normalized
@@ -188,9 +188,9 @@ export function equalForKeys(a, b, keys: string[] = Object.keys(a)) {
   return true;
 }
 
-type PickOmitPredicate = (keys: string[], key) => boolean;
-function pickOmitImpl(predicate: PickOmitPredicate, obj) {
-  let objCopy = {}, keys = restArgs(arguments, 2);
+type PickOmitPredicate = (keys: string[], key: any) => boolean;
+function pickOmitImpl(predicate: PickOmitPredicate, obj: any) {
+  let objCopy: { [key:string]: any; } = {}, keys = restArgs(arguments, 2);
   for (var key in obj) {
     if (predicate(keys, key)) objCopy[key] = obj[key];
   }
@@ -207,7 +207,7 @@ function pickOmitImpl(predicate: PickOmitPredicate, obj) {
  * @param obj the source object
  * @param propNames an Array of strings, which are the whitelisted property names
  */
-export function pick(obj, propNames: string[]): Object;
+export function pick(obj: any, propNames: string[]): Object;
 /**
  * @example
  * ```
@@ -218,9 +218,9 @@ export function pick(obj, propNames: string[]): Object;
  * @param obj the source object
  * @param propNames 1..n strings, which are the whitelisted property names
  */
-export function pick(obj, ...propNames: string[]): Object;
+export function pick(obj: any, ...propNames: string[]): Object;
 /** Return a copy of the object only containing the whitelisted properties. */
-export function pick(obj) { return pickOmitImpl.apply(null, [inArray].concat(restArgs(arguments))); }
+export function pick(obj: any) { return pickOmitImpl.apply(null, [inArray].concat(restArgs(arguments))); }
 
 /**
  * @example
@@ -232,7 +232,7 @@ export function pick(obj) { return pickOmitImpl.apply(null, [inArray].concat(res
  * @param obj the source object
  * @param propNames an Array of strings, which are the blacklisted property names
  */
-export function omit(obj, propNames: string[]): Object;
+export function omit(obj: any, propNames: string[]): Object;
 /**
  * @example
  * ```
@@ -243,9 +243,9 @@ export function omit(obj, propNames: string[]): Object;
  * @param obj the source object
  * @param propNames 1..n strings, which are the blacklisted property names
  */
-export function omit(obj, ...propNames: string[]): Object;
+export function omit(obj: any, ...propNames: string[]): Object;
 /** Return a copy of the object omitting the blacklisted properties. */
-export function omit(obj) { return pickOmitImpl.apply(null, [not(inArray)].concat(restArgs(arguments))); }
+export function omit(obj: any) { return pickOmitImpl.apply(null, [not(inArray)].concat(restArgs(arguments))); }
 
 
 /** Given an array of objects, maps each element to a named property of the element. */
@@ -255,20 +255,20 @@ export function pluck(collection: { [key: string]: any }, propName: string): { [
 /**
  * Maps an array, or object to a property (by name)
  */
-export function pluck(collection, propName): any {
+export function pluck(collection: any, propName: any): any {
   return map(collection, <Mapper<any, string>> prop(propName));
 }
 
 
 /** Given an array of objects, returns a new array containing only the elements which passed the callback predicate */
-export function filter<T>(collection: T[], callback: (T, key?) => boolean): T[];
+export function filter<T>(collection: T[], callback: (T: any, key?: any) => boolean): T[];
 /** Given an object, returns a new object with only those properties that passed the callback predicate */
-export function filter<T>(collection: TypedMap<T>, callback: (T, key?) => boolean): TypedMap<T>;
+export function filter<T>(collection: TypedMap<T>, callback: (T: any, key?: any) => boolean): TypedMap<T>;
 /** Filters an Array or an Object's properties based on a predicate */
 export function filter<T>(collection: T, callback: Function): T {
   let arr = isArray(collection), result: any = arr ? [] : {};
-  let accept = arr ? x => result.push(x) : (x, key) => result[key] = x;
-  forEach(collection, function(item, i) {
+  let accept = arr ? (x: any) => result.push(x) : (x: any, key: any) => result[key] = x;
+  forEach(collection, function(item: any, i: any) {
     if (callback(item, i)) accept(item, i);
   });
   return <T>result;
@@ -280,10 +280,10 @@ export function find<T>(collection: TypedMap<T>, callback: Predicate<T>): T;
 /** Given an array of objects, returns the first object which passed the callback predicate */
 export function find<T>(collection: T[], callback: Predicate<T>): T;
 /** Finds an object from an array, or a property of an object, that matches a predicate */
-export function find(collection, callback) {
-  let result;
+export function find(collection: any, callback: any) {
+  let result: any;
 
-  forEach(collection, function(item, i) {
+  forEach(collection, function(item: any, i: any) {
     if (result) return;
     if (callback(item, i)) result = item;
   });
@@ -298,8 +298,8 @@ export function map<T, U>(collection: T[], callback: Mapper<T, U>): U[];
 export function map<T, U>(collection: { [key: string]: T }, callback: Mapper<T, U>): { [key: string]: U }
 /** Maps an array or object properties using a callback function */
 export function map(collection: any, callback: any): any {
-  let result = isArray(collection) ? [] : {};
-  forEach(collection, (item, i) => result[i] = callback(item, i));
+  let result: any = isArray(collection) ? [] : {};
+  forEach(collection, (item: any, i: any) => result[i] = callback(item, i));
   return result;
 }
 
@@ -313,7 +313,7 @@ export function map(collection: any, callback: any): any {
  * let vals = values(foo); // [ 1, 2, 3 ]
  * ```
  */
-export const values: (<T> (obj: TypedMap<T>) => T[]) = (obj) => Object.keys(obj).map(key => obj[key]);
+export const values: (<T> (obj: TypedMap<T>) => T[]) = (obj: any) => Object.keys(obj).map(key => obj[key]);
 
 /**
  * Reduce function that returns true if all of the values are truthy.
@@ -328,7 +328,7 @@ export const values: (<T> (obj: TypedMap<T>) => T[]) = (obj) => Object.keys(obj)
  * vals.reduce(allTrueR, true); // false
  * ```
  */
-export const allTrueR  = (memo: boolean, elem) => memo && elem;
+export const allTrueR  = (memo: boolean, elem: any) => memo && elem;
 
 /**
  * Reduce function that returns true if any of the values are truthy.
@@ -343,7 +343,7 @@ export const allTrueR  = (memo: boolean, elem) => memo && elem;
  * vals.reduce(anyTrueR, true); // true
  * ```
  */
-export const anyTrueR  = (memo: boolean, elem) => memo || elem;
+export const anyTrueR  = (memo: boolean, elem: any) => memo || elem;
 
 /**
  * Reduce function which un-nests a single level of arrays
@@ -354,7 +354,7 @@ export const anyTrueR  = (memo: boolean, elem) => memo || elem;
  * input.reduce(unnestR, []) // [ "a", "b", "c", "d", [ "double, "nested" ] ]
  * ```
  */
-export const unnestR   = (memo: any[], elem) => memo.concat(elem);
+export const unnestR   = (memo: any[], elem: any) => memo.concat(elem);
 
 /**
  * Reduce function which recursively un-nests all arrays
@@ -366,12 +366,12 @@ export const unnestR   = (memo: any[], elem) => memo.concat(elem);
  * input.reduce(unnestR, []) // [ "a", "b", "c", "d", "double, "nested" ]
  * ```
  */
-export const flattenR  = (memo: any[], elem) => isArray(elem) ? memo.concat(elem.reduce(flattenR, [])) : pushR(memo, elem);
+export const flattenR  = (memo: any[], elem: any) => isArray(elem) ? memo.concat(elem.reduce(flattenR, [])) : pushR(memo, elem);
 /** Reduce function that pushes an object to an array, then returns the array.  Mostly just for [[flattenR]] */
-export function pushR(arr: any[], obj) { arr.push(obj); return arr; }
+export function pushR(arr: any[], obj: any) { arr.push(obj); return arr; }
 
 /** Reduce function that filters out duplicates */
-export const uniqR = (acc, token) => inArray(acc, token) ? acc : pushR(acc, token);
+export const uniqR = (acc: any, token: any) => inArray(acc, token) ? acc : pushR(acc, token);
 
 /**
  * Return a new array with a single level of arrays unnested.
@@ -427,7 +427,7 @@ export function assertPredicate<T>(predicate: Predicate<T>, errMsg: (string|Func
  * pairs({ foo: "FOO", bar: "BAR }) // [ [ "foo", "FOO" ], [ "bar": "BAR" ] ]
  * ```
  */
-export const pairs = (object) => Object.keys(object).map(key => [ key, object[key]] );
+export const pairs = (object: any) => Object.keys(object).map(key => [ key, object[key]] );
 
 /**
  * Given two or more parallel arrays, returns an array of tuples where
@@ -446,7 +446,7 @@ export const pairs = (object) => Object.keys(object).map(key => [ key, object[ke
 export function arrayTuples(...arrayArgs: any[]): any[] {
   if (arrayArgs.length === 0) return [];
   let length = arrayArgs.reduce((min, arr) => Math.min(arr.length, min), 9007199254740991); // aka 2^53 − 1 aka Number.MAX_SAFE_INTEGER
-  return Array.apply(null, Array(length)).map((ignored, idx) => arrayArgs.map(arr => arr[idx]));
+  return Array.apply(null, Array(length)).map((ignored: any, idx: any) => arrayArgs.map(arr => arr[idx]));
 }
 
 /**
@@ -470,7 +470,7 @@ export function arrayTuples(...arrayArgs: any[]): any[] {
  * ```
  */
 export function applyPairs(memo: TypedMap<any>, keyValTuple: any[]) {
-  let key, value;
+  let key: any, value: any;
   if (isArray(keyValTuple)) [key, value] = keyValTuple;
   if (!isString(key)) throw new Error("invalid parameters to applyPairs");
   memo[key] = value;
@@ -488,25 +488,25 @@ export function tail<T>(arr: T[]): T {
  * note: This is a shallow copy, while angular.copy is a deep copy.
  * ui-router uses `copy` only to make copies of state parameters.
  */
-function _copy(src, dest) {
+function _copy(src: any, dest: any) {
   if (dest) Object.keys(dest).forEach(key => delete dest[key]);
   if (!dest) dest = {};
   return extend(dest, src);
 }
 
-function _forEach(obj: (any[]|any), cb, _this) {
+function _forEach(obj: (any[]|any), cb: any, _this: any) {
   if (isArray(obj)) return obj.forEach(cb, _this);
   Object.keys(obj).forEach(key => cb(obj[key], key));
 }
 
-function _copyProps(to, from) { Object.keys(from).forEach(key => to[key] = from[key]); return to; }
-function _extend(toObj, fromObj);
-function _extend(toObj, ...fromObj);
-function _extend(toObj, rest) {
+function _copyProps(to: any, from: any) { Object.keys(from).forEach(key => to[key] = from[key]); return to; }
+function _extend(toObj: any, fromObj: any): any;
+function _extend(toObj: any, ...fromObj: any[]): any;
+function _extend(toObj: any, rest: any) {
   return restArgs(arguments, 1).filter(identity).reduce(_copyProps, toObj);
 }
 
-function _equals(o1, o2) {
+function _equals(o1: any, o2: any): any {
   if (o1 === o2) return true;
   if (o1 === null || o2 === null) return false;
   if (o1 !== o1 && o2 !== o2) return true; // NaN === NaN
@@ -522,7 +522,7 @@ function _equals(o1, o2) {
   let predicates = [isFunction, isArray, isDate, isRegExp];
   if (predicates.map(any).reduce((b, fn) => b || !!fn(tup), false)) return false;
 
-  let key, keys = {};
+  let key: any, keys: any = {};
   for (key in o1) {
     if (!_equals(o1[key], o2[key])) return false;
     keys[key] = true;
@@ -534,7 +534,7 @@ function _equals(o1, o2) {
   return true;
 }
 
-function _arraysEq(a1, a2) {
+function _arraysEq(a1: any, a2: any) {
   if (a1.length !== a2.length) return false;
   return arrayTuples(a1, a2).reduce((b, t) => b && _equals(t[0], t[1]), true);
 }

--- a/src/common/coreservices.ts
+++ b/src/common/coreservices.ts
@@ -9,7 +9,7 @@
 //import {IQService} from "angular";
 //import {IInjectorService} from "angular";
 
-let notImplemented = (fnname) => () => {
+let notImplemented = (fnname: any) => () => {
   throw new Error(`${fnname}(): No coreservices implementation for UI-Router is loaded. You should include one of: ['angular1.js']`);
 };
 
@@ -22,14 +22,14 @@ let services: CoreServices = {
 };
 
 ["replace", "url", "path", "search", "hash", "onChange"]
-    .forEach(key => services.location[key] = notImplemented(key));
+    .forEach(key => (<any>services.location)[key] = notImplemented(key));
 
 ["port", "protocol", "host", "baseHref", "html5Mode", "hashPrefix" ]
-    .forEach(key => services.locationConfig[key] = notImplemented(key));
+    .forEach(key => (<any>services.locationConfig)[key] = notImplemented(key));
 
 export interface CoreServices {
-  $q; // : IQService;
-  $injector; // : IInjectorService;
+  $q: any; // : IQService;
+  $injector: any; // : IInjectorService;
   /** Services related to getting or setting the browser location (url) */
   location: LocationServices;
   /** Retrieves configuration for how to construct a URL. */

--- a/src/common/hof.ts
+++ b/src/common/hof.ts
@@ -52,7 +52,7 @@ export function curry(fn: Function): Function {
   let initial_args = [].slice.apply(arguments, [1]);
   let func_args_length = fn.length;
 
-  function curried(args) {
+  function curried(args: any) {
     if (args.length >= func_args_length)
       return fn.apply(null, args);
     return function () {
@@ -121,22 +121,22 @@ export const parse = (name: string) => pipe.apply(null, name.split(".").map(prop
  * Given a function that returns a truthy or falsey value, returns a
  * function that returns the opposite (falsey or truthy) value given the same inputs
  */
-export const not = (fn) => (...args) => !fn.apply(null, args);
+export const not = (fn: any) => (...args: any[]) => !fn.apply(null, args);
 
 /**
  * Given two functions that return truthy or falsey values, returns a function that returns truthy
  * if both functions return truthy for the given arguments
  */
-export function and(fn1, fn2): Predicate<any> {
-  return (...args) => fn1.apply(null, args) && fn2.apply(null, args);
+export function and(fn1: any, fn2: any): Predicate<any> {
+  return (...args: any[]) => fn1.apply(null, args) && fn2.apply(null, args);
 }
 
 /**
  * Given two functions that return truthy or falsey values, returns a function that returns truthy
  * if at least one of the functions returns truthy for the given arguments
  */
-export function or(fn1, fn2): Predicate<any> {
-  return (...args) => fn1.apply(null, args) || fn2.apply(null, args);
+export function or(fn1: any, fn2: any): Predicate<any> {
+  return (...args: any[]) => fn1.apply(null, args) || fn2.apply(null, args);
 }
 
 /**
@@ -145,16 +145,16 @@ export function or(fn1, fn2): Predicate<any> {
  * @param fn1 a predicate function `fn1`
  * @returns a function which takes an array and returns true if `fn1` is true for all elements of the array
  */
-export const all = (fn1) => (arr: any[]) => arr.reduce((b, x) => b && !!fn1(x), true);
-export const any = (fn1) => (arr: any[]) => arr.reduce((b, x) => b || !!fn1(x), false);
+export const all = (fn1: any) => (arr: any[]) => arr.reduce((b, x) => b && !!fn1(x), true);
+export const any = (fn1: any) => (arr: any[]) => arr.reduce((b, x) => b || !!fn1(x), false);
 export const none: Function = not(any);
 
 /** Given a class, returns a Predicate function that returns true if the object is of that class */
-export const is: (ctor) => (x) => boolean =
+export const is: (ctor: any) => (x: any) => boolean =
     ctor => obj => (obj != null && obj.constructor === ctor || obj instanceof ctor);
 
 /** Given a value, returns a Predicate function that returns true if another value is === equal to the original value */
-export const eq: (comp) => (x) => boolean =
+export const eq: (comp: any) => (x: any) => boolean =
     (val) => (other) => val === other;
 
 /** Given a value, returns a function which returns the value */
@@ -164,7 +164,7 @@ export const val = <T> (v: T) => () => v;
 
 export function invoke(fnName: string): Function;
 export function invoke(fnName: string, args: any[]): Function;
-export function invoke(fnName: string, args?): Function {
+export function invoke(fnName: string, args?: any): Function {
   return (obj: any) => obj[fnName].apply(obj, args);
 }
 
@@ -209,7 +209,7 @@ export function invoke(fnName: string, args?): Function {
  * @returns {function(any): *}
  */
 export function pattern(struct: Function[][]): Function {
-  return function(x) {
+  return function(x: any) {
     for (var i = 0; i < struct.length; i++) {
       if (struct[i][0](x)) return struct[i][1](x);
     }

--- a/src/common/predicates.ts
+++ b/src/common/predicates.ts
@@ -2,17 +2,17 @@
 import {and, not, pipe, prop} from "./hof";
 
 const toStr = Object.prototype.toString;
-const tis = (t) => (x) => typeof(x) === t;
+const tis = (t: any) => (x: any) => typeof(x) === t;
 export const isUndefined = tis('undefined');
 export const isDefined = not(isUndefined);
-export const isNull = o => o === null;
-export const isFunction: (x) => x is Function = <any> tis('function');
-export const isNumber: (x) => x is number = <any> tis('number');
-export const isString = <(x) => x is string> tis('string');
-export const isObject = (x) => x !== null && typeof x === 'object';
+export const isNull = (o: any) => o === null;
+export const isFunction: (x: any) => x is Function = <any> tis('function');
+export const isNumber: (x: any) => x is number = <any> tis('number');
+export const isString = <(x: any) => x is string> tis('string');
+export const isObject = (x: any) => x !== null && typeof x === 'object';
 export const isArray = Array.isArray;
-export const isDate: (x) => x is Date = <any> ((x) => toStr.call(x) === '[object Date]');
-export const isRegExp: (x) => x is RegExp = <any> ((x) => toStr.call(x) === '[object RegExp]');
+export const isDate: (x: any) => x is Date = <any> ((x: any) => toStr.call(x) === '[object Date]');
+export const isRegExp: (x: any) => x is RegExp = <any> ((x: any) => toStr.call(x) === '[object RegExp]');
 
 /**
  * Predicate which checks if a value is injectable
@@ -20,7 +20,7 @@ export const isRegExp: (x) => x is RegExp = <any> ((x) => toStr.call(x) === '[ob
  * A value is "injectable" if it is a function, or if it is an ng1 array-notation-style array
  * where all the elements in the array are Strings, except the last one, which is a Function
  */
-export function isInjectable(val) {
+export function isInjectable(val: any) {
   if (isArray(val) && val.length) {
     let head = val.slice(0, -1), tail = val.slice(-1);
     return !(head.filter(not(isString)).length || tail.filter(not(isFunction)).length);

--- a/src/common/strings.ts
+++ b/src/common/strings.ts
@@ -65,8 +65,8 @@ export function fnToString(fn: IInjectable) {
   return _fn && _fn.toString() || "undefined";
 }
 
-let stringifyPatternFn = null;
-let stringifyPattern = function(value) {
+let stringifyPatternFn = null as any;
+let stringifyPattern = function(value: any) {
   let isTransitionRejectionPromise = Rejection.isTransitionRejectionPromise;
 
   stringifyPatternFn = stringifyPatternFn || pattern([

--- a/src/common/trace.ts
+++ b/src/common/trace.ts
@@ -39,7 +39,7 @@ import {PathNode} from "../path/node";
 import {PolicyWhen} from "../resolve/interface";
 
 /** @hidden */
-function uiViewString (viewData) {
+function uiViewString (viewData: any) {
     if (!viewData) return 'ui-view (defunct)';
     return `[ui-view#${viewData.id} tag ` +
         `in template from '${viewData.creationContext && viewData.creationContext.name || '(root)'}' state]: ` +
@@ -53,7 +53,7 @@ const viewConfigString = (viewConfig: ViewConfig) =>
 
 /** @hidden */
 function normalizedCat(input: Category): string {
-  return isNumber(input) ? Category[input] : Category[Category[input]];
+  return isNumber(input) ? Category[input] : Category[Category[input] as any];
 }
 
 
@@ -92,7 +92,7 @@ export class Trace {
     if (!categories.length) {
       categories = Object.keys(Category)
           .filter(k => isNaN(parseInt(k, 10)))
-          .map(key => Category[key]);
+          .map(key => (<Category>(<any>Category[key as any])));
     }
     categories.map(normalizedCat).forEach(category => this._enabled[category] = enabled);
   }
@@ -152,7 +152,7 @@ export class Trace {
   }
 
   /** called by ui-router code */
-  traceHookInvocation(step, options) {
+  traceHookInvocation(step: any, options: any) {
     if (!this.enabled(Category.HOOK)) return;
     let tid = parse("transition.$id")(options),
         digest = this.approximateDigests,
@@ -163,7 +163,7 @@ export class Trace {
   }
 
   /** called by ui-router code */
-  traceHookResult(hookResult, transitionResult, transitionOptions) {
+  traceHookResult(hookResult: any, transitionResult: any, transitionOptions: any) {
     if (!this.enabled(Category.HOOK)) return;
     let tid = parse("transition.$id")(transitionOptions),
         digest = this.approximateDigests,
@@ -192,7 +192,7 @@ export class Trace {
   }
 
   /** called by ui-router code */
-  traceError(error, trans: Transition) {
+  traceError(error: any, trans: Transition) {
     if (!this.enabled(Category.TRANSITION)) return;
     let tid = trans && trans.$id,
         digest = this.approximateDigests,
@@ -201,7 +201,7 @@ export class Trace {
   }
 
   /** called by ui-router code */
-  traceSuccess(finalState, trans: Transition) {
+  traceSuccess(finalState: any, trans: Transition) {
     if (!this.enabled(Category.TRANSITION)) return;
     let tid = trans && trans.$id,
         digest = this.approximateDigests,
@@ -217,19 +217,19 @@ export class Trace {
   }
 
   /** called by ui-router code */
-  traceUiViewConfigUpdated(viewData: ActiveUiView, context) {
+  traceUiViewConfigUpdated(viewData: ActiveUiView, context: any) {
     if (!this.enabled(Category.UIVIEW)) return;
     this.traceUiViewEvent("Updating", viewData, ` with ViewConfig from context='${context}'`);
   }
 
   /** called by ui-router code */
-  traceUiViewScopeCreated(viewData: ActiveUiView, newScope) {
+  traceUiViewScopeCreated(viewData: ActiveUiView, newScope: any) {
     if (!this.enabled(Category.UIVIEW)) return;
     this.traceUiViewEvent("Created scope for", viewData, `, scope #${newScope.$id}`);
   }
 
   /** called by ui-router code */
-  traceUiViewFill(viewData: ActiveUiView, html) {
+  traceUiViewFill(viewData: ActiveUiView, html: any) {
     if (!this.enabled(Category.UIVIEW)) return;
     this.traceUiViewEvent("Fill", viewData, ` with: ${maxLength(200, html)}`);
   }

--- a/src/hooks/redirectTo.ts
+++ b/src/hooks/redirectTo.ts
@@ -22,7 +22,7 @@ export const redirectToHook = (transition: Transition, $injector: UIRInjector) =
 
   return handleResult(redirect);
 
-  function handleResult(result) {
+  function handleResult(result: any) {
     if (result instanceof TargetState) return result;
     if (isString(result)) return $state.target(<any> result, transition.params(), transition.options());
     if (result['state'] || result['params'])

--- a/src/hooks/resolve.ts
+++ b/src/hooks/resolve.ts
@@ -9,6 +9,6 @@ export const $eagerResolvePath = (trans: Transition) =>
     new ResolveContext(trans.treeChanges().to).resolvePath("EAGER", trans).then(noop);
 
 /** A function which resolves all LAZY Resolvables for the state (and all ancestors) in the To Path */
-export const $lazyResolveState = (trans: Transition, injector, state: State) =>
+export const $lazyResolveState = (trans: Transition, injector: any, state: State) =>
     new ResolveContext(trans.treeChanges().to).subContext(state).resolvePath("LAZY", trans).then(noop);
 

--- a/src/hooks/views.ts
+++ b/src/hooks/views.ts
@@ -10,10 +10,10 @@ import {UiRouter} from "../router";
 
 
 /** Allows the views to do async work [.load()] before the transition continues */
-export function loadEnteringViews(transition) {
+export function loadEnteringViews(transition: any) {
   let enteringViews = transition.views("entering");
   if (!enteringViews.length) return;
-  return services.$q.all(enteringViews.map(view => view.load())).then(noop);
+  return services.$q.all(enteringViews.map((view: any) => view.load())).then(noop);
 }
 
 export function activateViews(transition: Transition, injector: UIRInjector) {

--- a/src/justjs.ts
+++ b/src/justjs.ts
@@ -10,9 +10,9 @@ import {isFunction, isArray, isObject, isInjectable} from "./common/predicates";
 import {extend, assertPredicate} from "./common/common";
 
 /** $q-like promise api */
-services.$q = (executor: (resolve, reject) => void) => new Promise(executor);
-services.$q.when = (val) => Promise.resolve(val);
-services.$q.reject = (val) => Promise.reject(val);
+services.$q = (executor: (resolve: any, reject: any) => void) => new Promise(executor);
+services.$q.when = (val: any) => Promise.resolve(val);
+services.$q.reject = (val: any) => Promise.reject(val);
 services.$q.defer = function() {
   let deferred: any = {};
   deferred.promise = new Promise((resolve, reject) => {
@@ -32,10 +32,10 @@ services.$q.all = function (promises: { [key: string]: Promise<any> } | Promise<
     // Convert promises map to promises array.
     // When each promise resolves, map it to a tuple { key: key, val: val }
     let objectToTuples = Object.keys(promises)
-        .map(key => promises[key].then(val => ({key, val})));
+        .map(key => (<any>promises)[key].then((val: any) => ({key, val})));
 
-    const tuplesToObject = values =>
-        values.reduce((acc, tuple) => { acc[tuple.key] = tuple.val; return acc; }, {});
+    const tuplesToObject = (values: any) =>
+        values.reduce((acc: any, tuple: any) => { acc[tuple.key] = tuple.val; return acc; }, {});
 
     // Then wait for all promises to resolve, and convert them back to an object
     return services.$q.all(objectToTuples).then(tuplesToObject);
@@ -49,16 +49,16 @@ services.$q.all = function (promises: { [key: string]: Promise<any> } | Promise<
 // angular1-like injector api
 
 // globally available injectables
-let globals = { };
+let globals: { [key: string]: any; } = { };
 services.$injector = { };
 
-services.$injector.get = name => globals[name];
-services.$injector.has = (name) => services.$injector.get(name) != null;
-services.$injector.invoke = function(fn, context?, locals?) {
+services.$injector.get = (name: any) => globals[name];
+services.$injector.has = (name: any) => services.$injector.get(name) != null;
+services.$injector.invoke = function(fn: any, context?: any, locals?: any) {
   let all = extend({}, globals, locals || {});
   let params = services.$injector.annotate(fn);
-  let ensureExist = assertPredicate(key => all.hasOwnProperty(key), key => `Could not find Dependency Injection token: ${stringify(key)}`);
-  let args = params.filter(ensureExist).map(x => all[x]);
+  let ensureExist = assertPredicate(key => all.hasOwnProperty(key), (key: any) => `Could not find Dependency Injection token: ${stringify(key)}`);
+  let args = params.filter(ensureExist).map((x: any) => all[x]);
   if (isFunction(fn)) return fn.apply(context, args);
   return fn.slice(-1)[0].apply(context, args);
 };
@@ -66,7 +66,7 @@ services.$injector.invoke = function(fn, context?, locals?) {
 let STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 let ARGUMENT_NAMES = /([^\s,]+)/g;
 // http://stackoverflow.com/questions/1007981
-services.$injector.annotate = function(fn) {
+services.$injector.annotate = function(fn: any) {
   if (!isInjectable(fn)) throw new Error(`Not an injectable function: ${fn}`);
   if (fn && fn.$inject) return fn.$inject;
   if (isArray(fn)) return fn.slice(0, -1);
@@ -80,9 +80,9 @@ let loc = <any> services.location;
 loc.hash = () => "";
 loc.path = () => location.hash.replace(/^#/, "");
 loc.search = () => location.search;
-loc.url = (url) => { if (url) location.hash = url; return loc.path(); };
+loc.url = (url: any) => { if (url) location.hash = url; return loc.path(); };
 loc.replace = () => { console.log(new Error("not impl")); };
-loc.onChange = (cb) => {
+loc.onChange = (cb: any) => {
   window.addEventListener("hashchange", cb, false);
 };
 

--- a/src/ng1/directives/stateDirectives.ts
+++ b/src/ng1/directives/stateDirectives.ts
@@ -12,8 +12,8 @@ import {parse} from "../../common/hof";
 import {PathNode} from "../../path/node";
 
 /** @hidden */
-function parseStateRef(ref, current) {
-  let preparsed = ref.match(/^\s*({[^}]*})\s*$/), parsed;
+function parseStateRef(ref: any, current: any) {
+  let preparsed = ref.match(/^\s*({[^}]*})\s*$/), parsed: any;
   if (preparsed) ref = current + '(' + preparsed[1] + ')';
   parsed = ref.replace(/\n/g, " ").match(/^([^(]+?)\s*(\((.*)\))?$/);
   if (!parsed || parsed.length !== 4) throw new Error("Invalid state ref '" + ref + "'");
@@ -21,14 +21,14 @@ function parseStateRef(ref, current) {
 }
 
 /** @hidden */
-function stateContext(el) {
+function stateContext(el: any) {
   let $uiView: UiViewData = el.parent().inheritedData('$uiView');
   let path: PathNode[] = parse('$cfg.path')($uiView);
   return path ? tail(path).state.name : undefined;
 }
 
 /** @hidden */
-function getTypeInfo(el) {
+function getTypeInfo(el: any) {
   // SVGAElement does not use the href attribute, but rather the 'xlinkHref' attribute.
   var isSvg = Object.prototype.toString.call(el.prop('href')) === '[object SVGAnimatedString]';
   var isForm = el[0].nodeName === "FORM";
@@ -41,8 +41,8 @@ function getTypeInfo(el) {
 }
 
 /** @hidden */
-function clickHook(el, $state, $timeout, type, current) {
-  return function(e) {
+function clickHook(el: any, $state: any, $timeout: any, type: any, current: any) {
+  return function(e: any) {
     var button = e.which || e.button, target = current();
 
     if (!(button > 1 || e.ctrlKey || e.metaKey || e.shiftKey || el.attr('target'))) {
@@ -63,7 +63,7 @@ function clickHook(el, $state, $timeout, type, current) {
 }
 
 /** @hidden */
-function defaultOpts(el, $state) {
+function defaultOpts(el: any, $state: any) {
   return { relative: stateContext(el) || $state.$current, inherit: true };
 }
 
@@ -131,20 +131,20 @@ function defaultOpts(el, $state) {
  * @param {Object} ui-sref-opts options to pass to [[StateService.go]]
  */
 let uiSrefNg1 = ['$state', '$timeout',
-function $StateRefDirective($state, $timeout) {
+function $StateRefDirective($state: any, $timeout: any) {
   return {
     restrict: 'A',
     require: ['?^uiSrefActive', '?^uiSrefActiveEq'],
-    link: function(scope, element, attrs, uiSrefActive) {
+    link: function(scope: any, element: any, attrs: any, uiSrefActive: any) {
       var ref    = parseStateRef(attrs.uiSref, $state.current.name);
-      var def    = { state: ref.state, href: null, params: null, options: null };
+      var def    = { state: ref.state, href: null as any, params: null as any, options: null as any };
       var type   = getTypeInfo(element);
       var active = uiSrefActive[1] || uiSrefActive[0];
-      var unlinkInfoFn = null;
+      var unlinkInfoFn = null as any;
 
       def.options = extend(defaultOpts(element, $state), attrs.uiSrefOpts ? scope.$eval(attrs.uiSrefOpts) : {});
 
-      var update = function(val?) {
+      var update = function(val?: any) {
         if (val) def.params = angular.copy(val);
         def.href = $state.href(ref.state, def.params, def.options);
 
@@ -154,7 +154,7 @@ function $StateRefDirective($state, $timeout) {
       };
 
       if (ref.paramExpr) {
-        scope.$watch(ref.paramExpr, function(val) { if (val !== def.params) update(val); }, true);
+        scope.$watch(ref.paramExpr, function(val: any) { if (val !== def.params) update(val); }, true);
         def.params = angular.copy(scope.$eval(ref.paramExpr));
       }
       update();
@@ -183,19 +183,19 @@ function $StateRefDirective($state, $timeout) {
  * @param {Object} ui-state-opts options to pass to [[StateService.go]]
  */
 let uiStateNg1 = ['$state', '$timeout',
-function $StateRefDynamicDirective($state, $timeout) {
+function $StateRefDynamicDirective($state: any, $timeout: any) {
   return {
     restrict: 'A',
     require: ['?^uiSrefActive', '?^uiSrefActiveEq'],
-    link: function(scope, element, attrs, uiSrefActive) {
+    link: function(scope: any, element: any, attrs: any, uiSrefActive: any) {
       var type   = getTypeInfo(element);
       var active = uiSrefActive[1] || uiSrefActive[0];
       var group  = [attrs.uiState, attrs.uiStateParams || null, attrs.uiStateOpts || null];
       var watch  = '[' + group.map(function(val) { return val || 'null'; }).join(', ') + ']';
-      var def    = { state: null, params: null, options: null, href: null };
-      var unlinkInfoFn = null;
+      var def    = { state: null as any, params: null as any, options: null as any, href: null as any };
+      var unlinkInfoFn = null as any;
 
-      function runStateRefLink (group) {
+      function runStateRefLink (group: any) {
         def.state = group[0]; def.params = group[1]; def.options = group[2];
         def.href = $state.href(def.state, def.params, def.options);
 
@@ -295,11 +295,11 @@ function $StateRefDynamicDirective($state, $timeout) {
  * names/globs passed to ui-sref-active shadow the state provided by ui-sref.
  */
 let uiSrefActiveNg1 = ['$state', '$stateParams', '$interpolate', '$transitions',
-function $StateRefActiveDirective($state, $stateParams, $interpolate, $transitions) {
+function $StateRefActiveDirective($state: any, $stateParams: any, $interpolate: any, $transitions: any) {
   return  {
     restrict: "A",
-    controller: ['$scope', '$element', '$attrs', '$timeout', function ($scope, $element, $attrs, $timeout) {
-      var states = [], activeClasses = {}, activeEqClass, uiSrefActive;
+    controller: ['$scope', '$element', '$attrs', '$timeout', function ($scope: any, $element: any, $attrs: any, $timeout: any) {
+      var states: any[] = [], activeClasses: { [key: string]: any; } = {}, activeEqClass: any, uiSrefActive: any;
 
       // There probably isn't much point in $observing this
       // uiSrefActive and uiSrefActiveEq share the same directive object with some
@@ -314,7 +314,7 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate, $transitio
       }
       uiSrefActive = uiSrefActive || $interpolate($attrs.uiSrefActive || '', false)($scope);
       if (isObject(uiSrefActive)) {
-        forEach(uiSrefActive, function(stateOrName, activeClass) {
+        forEach(uiSrefActive, function(stateOrName: any, activeClass: any) {
           if (isString(stateOrName)) {
             var ref = parseStateRef(stateOrName, $state.current.name);
             addState(ref.state, $scope.$eval(ref.paramExpr), activeClass);
@@ -323,7 +323,7 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate, $transitio
       }
 
       // Allow uiSref to communicate with uiSrefActive[Equals]
-      this.$$addStateInfo = function (newState, newParams) {
+      this.$$addStateInfo = function (newState: any, newParams: any) {
         // we already got an explicit state provided by ui-sref-active, so we
         // shadow the one that comes from ui-sref
         if (isObject(uiSrefActive) && states.length > 0) {
@@ -335,9 +335,9 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate, $transitio
       };
 
       $scope.$on('$stateChangeSuccess', update);
-      $scope.$on('$destroy', $transitions.onStart({}, (trans) => trans.promise.then(update) && null));
+      $scope.$on('$destroy', $transitions.onStart({}, (trans: any) => trans.promise.then(update) && null as any));
 
-      function addState(stateName, stateParams, activeClass) {
+      function addState(stateName: any, stateParams: any, activeClass: any) {
         var state = $state.get(stateName, stateContext($element));
         var stateHash = createStateHash(stateName, stateParams);
 
@@ -361,7 +361,7 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate, $transitio
        * @param {Object|string} [params]
        * @return {string}
        */
-      function createStateHash(state, params) {
+      function createStateHash(state: any, params: any) {
         if (!isString(state)) {
           throw new Error('state should be a string');
         }
@@ -392,10 +392,10 @@ function $StateRefActiveDirective($state, $stateParams, $interpolate, $transitio
         }
       }
 
-      function addClass(el, className) { $timeout(function () { el.addClass(className); }); }
-      function removeClass(el, className) { el.removeClass(className); }
-      function anyMatch(state, params) { return $state.includes(state.name, params); }
-      function exactMatch(state, params) { return $state.is(state.name, params); }
+      function addClass(el: any, className: any) { $timeout(function () { el.addClass(className); }); }
+      function removeClass(el: any, className: any) { el.removeClass(className); }
+      function anyMatch(state: any, params: any) { return $state.includes(state.name, params); }
+      function exactMatch(state: any, params: any) { return $state.is(state.name, params); }
 
       update();
     }]

--- a/src/ng1/directives/viewDirective.ts
+++ b/src/ng1/directives/viewDirective.ts
@@ -23,7 +23,7 @@ export type UiViewData = {
 
   $animEnter: Promise<any>;
   $animLeave: Promise<any>;
-  $$animLeave: { resolve(); } // "deferred"
+  $$animLeave: { resolve(): any; } // "deferred"
 }
 
 /**
@@ -156,18 +156,18 @@ export type UiViewData = {
  * ```
  */
 let uiViewNg1 = ['$view', '$animate', '$uiViewScroll', '$interpolate', '$q',
-function $ViewDirective(   $view,   $animate,   $uiViewScroll,   $interpolate,   $q) {
+function $ViewDirective($view: any, $animate: any, $uiViewScroll: any, $interpolate: any, $q: any) {
 
-  function getRenderer(attrs, scope) {
+  function getRenderer(attrs: any, scope: any) {
     return {
-      enter: function(element, target, cb) {
+      enter: function(element: any, target: any, cb: any) {
         if (angular.version.minor > 2) {
           $animate.enter(element, null, target).then(cb);
         } else {
           $animate.enter(element, null, target, cb);
         }
       },
-      leave: function(element, cb) {
+      leave: function(element: any, cb: any) {
         if (angular.version.minor > 2) {
           $animate.leave(element).then(cb);
         } else {
@@ -177,7 +177,7 @@ function $ViewDirective(   $view,   $animate,   $uiViewScroll,   $interpolate,  
     };
   }
 
-  function configsEqual(config1, config2) {
+  function configsEqual(config1: any, config2: any) {
     return config1 === config2;
   }
 
@@ -192,14 +192,14 @@ function $ViewDirective(   $view,   $animate,   $uiViewScroll,   $interpolate,  
     terminal: true,
     priority: 400,
     transclude: 'element',
-    compile: function (tElement, tAttrs, $transclude) {
+    compile: function (tElement: any, tAttrs: any, $transclude: any) {
 
-      return function (scope, $element, attrs) {
-        let previousEl, currentEl, currentScope, unregister,
+      return function (scope: any, $element: any, attrs: any) {
+        let previousEl: any, currentEl: any, currentScope: any, unregister: any,
             onloadExp     = attrs.onload || '',
             autoScrollExp = attrs.autoscroll,
             renderer      = getRenderer(attrs, scope),
-            viewConfig    = undefined,
+            viewConfig    = undefined as any,
             inherited     = $element.inheritedData('$uiView') || rootData,
             name          = $interpolate(attrs.uiView || attrs.name || '')(scope) || '$default';
 
@@ -275,7 +275,7 @@ function $ViewDirective(   $view,   $animate,   $uiViewScroll,   $interpolate,  
             $$animLeave: animLeave
           };
 
-          let cloned = $transclude(newScope, function(clone) {
+          let cloned = $transclude(newScope, function(clone: any) {
             renderer.enter(clone.data('$uiView', $uiViewData), $element, function onUiViewEnter() {
               animEnter.resolve();
               if (currentScope) currentScope.$emit('$viewContentAnimationEnded');
@@ -312,17 +312,17 @@ function $ViewDirective(   $view,   $animate,   $uiViewScroll,   $interpolate,  
 
 $ViewDirectiveFill.$inject = ['$compile', '$controller', '$transitions', '$view', '$timeout'];
 /** @hidden */
-function $ViewDirectiveFill (  $compile,   $controller,   $transitions,   $view,   $timeout) {
+function $ViewDirectiveFill ($compile: any, $controller: any, $transitions: any, $view: any, $timeout: any) {
   const getControllerAs = parse('viewDecl.controllerAs');
   const getResolveAs = parse('viewDecl.resolveAs');
 
   return {
     restrict: 'ECA',
     priority: -400,
-    compile: function (tElement) {
+    compile: function (tElement: any) {
       let initial = tElement.html();
 
-      return function (scope, $element) {
+      return function (scope: any, $element: any) {
         let data: UiViewData = $element.data('$uiView');
         if (!data) return;
 
@@ -363,11 +363,11 @@ function $ViewDirectiveFill (  $compile,   $controller,   $transitions,   $view,
           let kebobName = kebobString(cmp);
           let getComponentController = () => {
             let directiveEl = [].slice.call($element[0].children)
-                .filter(el => el && el.tagName && el.tagName.toLowerCase() === kebobName) ;
+                .filter((el: any) => el && el.tagName && el.tagName.toLowerCase() === kebobName) ;
             return directiveEl && angular.element(directiveEl).data(`$${cmp}Controller`);
           };
 
-          let deregisterWatch = scope.$watch(getComponentController, function(ctrlInstance) {
+          let deregisterWatch = scope.$watch(getComponentController, function(ctrlInstance: any) {
             if (!ctrlInstance) return;
             registerControllerCallbacks($transitions, ctrlInstance, scope, cfg);
             deregisterWatch();
@@ -381,10 +381,10 @@ function $ViewDirectiveFill (  $compile,   $controller,   $transitions,   $view,
 }
 
 /** @hidden */
-let hasComponentImpl = typeof angular.module('ui.router')['component'] === 'function';
+let hasComponentImpl = typeof (<any>angular.module)('ui.router')['component'] === 'function';
 
 /** @hidden TODO: move these callbacks to $view and/or `/hooks/components.ts` or something */
-function registerControllerCallbacks($transitions: TransitionService, controllerInstance: Ng1Controller, $scope, cfg: Ng1ViewConfig) {
+function registerControllerCallbacks($transitions: TransitionService, controllerInstance: Ng1Controller, $scope: any, cfg: Ng1ViewConfig) {
   // Call $onInit() ASAP
   if (isFunction(controllerInstance.$onInit) && !(cfg.viewDecl.component && hasComponentImpl)) controllerInstance.$onInit();
 

--- a/src/ng1/interface.ts
+++ b/src/ng1/interface.ts
@@ -446,6 +446,7 @@ export interface Ng1ViewDeclaration extends _ViewDeclaration {
    */
   templateProvider?: IInjectable;
 
+  [key: string]: any;
 }
 
 /**
@@ -463,7 +464,7 @@ export interface Ng1ViewDeclaration extends _ViewDeclaration {
  */
 export interface Ng1Controller {
   /** @hidden */
-  $onInit();
+  $onInit(): any;
   /**
    * This callback is called when parameter values have changed.
    * 
@@ -490,7 +491,7 @@ export interface Ng1Controller {
    * });
    * ```
    */
-  uiOnParamsChanged(newValues: any, $transition$: Transition);
+  uiOnParamsChanged(newValues: any, $transition$: Transition): any;
 
   /**
    * This callback is called when the view's state is about to be exited.
@@ -517,5 +518,5 @@ export interface Ng1Controller {
    *
    * @return a value, or a promise for a value.
    */
-  uiCanExit();
+  uiCanExit(): any;
 }

--- a/src/ng1/legacy/resolveService.ts
+++ b/src/ng1/legacy/resolveService.ts
@@ -11,19 +11,19 @@ export const resolveFactory = () => ({
    * @param locals key/value pre-resolved data (locals)
    * @param parent a promise for a "parent resolve"
    */
-  resolve: (invocables, locals = {}, parent?) => {
+  resolve: (invocables: any, locals = {}, parent?: any) => {
     let parentNode = new PathNode(new State(<any> { params: {}, resolvables: [] }));
     let node = new PathNode(new State(<any> { params: {}, resolvables: [] }));
     let context = new ResolveContext([parentNode, node]);
 
     context.addResolvables(resolvablesBuilder(<any> { resolve: invocables }), node.state);
 
-    const resolveData = (parentLocals) => {
-      const rewrap = _locals => resolvablesBuilder(<any> { resolve: map(_locals, local => () => local) });
+    const resolveData = (parentLocals: any) => {
+      const rewrap = (_locals: any) => resolvablesBuilder(<any> { resolve: map(_locals, local => () => local) });
       context.addResolvables(rewrap(parentLocals), parentNode.state);
       context.addResolvables(rewrap(locals), node.state);
 
-      const tuples2ObjR = (acc, tuple) => {
+      const tuples2ObjR = (acc: any, tuple: any) => {
         acc[tuple.token] = tuple.value;
         return acc;
       };

--- a/src/ng1/legacy/stateEvents.ts
+++ b/src/ng1/legacy/stateEvents.ts
@@ -50,7 +50,7 @@ import {Transition} from "../../transition/transition";
  * @deprecated use [[TransitionService.onStart]]
  * @event $stateChangeStart
  */
-var $stateChangeStart;
+var $stateChangeStart: any;
 
 /**
  * An event broadcast on `$rootScope` if a transition is **cancelled**.
@@ -66,7 +66,7 @@ var $stateChangeStart;
  * @deprecated
  * @event $stateChangeCancel
  */
-var $stateChangeCancel;
+var $stateChangeCancel: any;
 
 /**
  *
@@ -83,7 +83,7 @@ var $stateChangeCancel;
  * @deprecated use [[TransitionService.onStart]] and [[Transition.promise]], or [[Transition.onSuccess]]
  * @event $stateChangeSuccess
  */
-var $stateChangeSuccess;
+var $stateChangeSuccess: any;
 
 /**
  * An event broadcast on `$rootScope` when an **error occurs** during transition.
@@ -105,7 +105,7 @@ var $stateChangeSuccess;
  * @deprecated use [[TransitionService.onStart]] and [[Transition.promise]], or [[Transition.onError]]
  * @event $stateChangeError
  */
-var $stateChangeError;
+var $stateChangeError: any;
 
 /**
  * An event broadcast on `$rootScope` when a requested state **cannot be found** using the provided state name.
@@ -139,21 +139,21 @@ var $stateChangeError;
  * @deprecated use [[StateProvider.onInvalid]] // TODO: Move to [[StateService.onInvalid]]
  * @event $stateNotFound
  */
-var $stateNotFound;
+var $stateNotFound: any;
 
 
 (function() {
   let {isFunction, isString} = angular;
 
-  function applyPairs(memo, keyValTuple: any[]) {
-    let key, value;
+  function applyPairs(memo: any, keyValTuple: any[]) {
+    let key: any, value: any;
     if (Array.isArray(keyValTuple)) [key, value] = keyValTuple;
     if (!isString(key)) throw new Error("invalid parameters to applyPairs");
     memo[key] = value;
     return memo;
   }
 
-  function stateChangeStartHandler($transition$: Transition, $injector) {
+  function stateChangeStartHandler($transition$: Transition, $injector: any) {
     if (!$transition$.options().notify || !$transition$.valid() || $transition$.ignored())
       return;
 
@@ -201,7 +201,7 @@ var $stateNotFound;
   }
 
   stateNotFoundHandler.$inject = ['$to$', '$from$', '$state', '$rootScope', '$urlRouter'];
-  function stateNotFoundHandler($to$: TargetState, $from$: TargetState, $state: StateService, $rootScope, $urlRouter) {
+  function stateNotFoundHandler($to$: TargetState, $from$: TargetState, $state: StateService, $rootScope: any, $urlRouter: any) {
     let redirect = {to: $to$.identifier(), toParams: $to$.params(), options: $to$.options()};
     let e = $rootScope.$broadcast('$stateNotFound', redirect, $from$.state(), $from$.params());
 
@@ -232,7 +232,7 @@ var $stateNotFound;
 
     let runtime = false;
     let allEvents = ['$stateChangeStart', '$stateNotFound', '$stateChangeSuccess', '$stateChangeError'];
-    let enabledStateEvents = <IEventsToggle> allEvents.map(e => [e, true]).reduce(applyPairs, {});
+    let enabledStateEvents: { [key: string]: any; } = <IEventsToggle> allEvents.map(e => [e, true]).reduce(applyPairs, {});
 
     function assertNotRuntime() {
       if (runtime) throw new Error("Cannot enable events at runtime (use $stateEventsProvider");
@@ -262,12 +262,12 @@ var $stateNotFound;
 
     this.$get = $get;
     $get.$inject = ['$transitions'];
-    function $get($transitions) {
+    function $get($transitions: any) {
       runtime = true;
 
       if (enabledStateEvents["$stateNotFound"])
         $stateProvider.onInvalid(stateNotFoundHandler);
-      if (enabledStateEvents.$stateChangeStart)
+      if (enabledStateEvents["$stateChangeStart"])
         $transitions.onBefore({}, stateChangeStartHandler, {priority: 1000});
 
       return {
@@ -279,6 +279,6 @@ var $stateNotFound;
 
   angular.module('ui.router.state.events', ['ui.router.state'])
       .provider("$stateEvents", <IServiceProviderFactory> $StateEventsProvider)
-      .run(['$stateEvents', function ($stateEvents) { /* Invokes $get() */
+      .run(['$stateEvents', function ($stateEvents: any) { /* Invokes $get() */
       }]);
 })();

--- a/src/ng1/services.ts
+++ b/src/ng1/services.ts
@@ -129,14 +129,14 @@ angular.module('ui.router.compat', ['ui.router']);
  * returns an array of strings, which are the arguments of the controller expression
  */
 
-export function annotateController(controllerExpression): string[] {
+export function annotateController(controllerExpression: any): string[] {
   let $injector = services.$injector;
   let $controller = $injector.get("$controller");
   let oldInstantiate = $injector.instantiate;
   try {
-    let deps;
+    let deps: any;
 
-    $injector.instantiate = function fakeInstantiate(constructorFunction) {
+    $injector.instantiate = function fakeInstantiate(constructorFunction: any) {
       $injector.instantiate = oldInstantiate; // Un-decorate ASAP
       deps = $injector.annotate(constructorFunction);
     };
@@ -150,7 +150,7 @@ export function annotateController(controllerExpression): string[] {
 }
 
 runBlock.$inject = ['$injector', '$q'];
-function runBlock($injector, $q) {
+function runBlock($injector: any, $q: any) {
   services.$injector = $injector;
   services.$q = $q;
 }
@@ -161,7 +161,7 @@ let router: UiRouter = null;
 
 ng1UiRouter.$inject = ['$locationProvider'];
 /** This angular 1 provider instantiates a Router and exposes its services via the angular injector */
-function ng1UiRouter($locationProvider) {
+function ng1UiRouter($locationProvider: any) {
 
   // Create a new instance of the Router when the ng1UiRouterProvider is initialized
   router = new UiRouter();
@@ -186,10 +186,10 @@ function ng1UiRouter($locationProvider) {
 
   this.$get = $get;
   $get.$inject = ['$location', '$browser', '$sniffer', '$rootScope', '$http', '$templateCache'];
-  function $get($location, $browser, $sniffer, $rootScope, $http, $templateCache) {
+  function $get($location: any, $browser: any, $sniffer: any, $rootScope: any, $http: any, $templateCache: any) {
 
     // Bind $locationChangeSuccess to the listeners registered in LocationService.onChange
-    $rootScope.$on("$locationChangeSuccess", evt => urlListeners.forEach(fn => fn(evt)));
+    $rootScope.$on("$locationChangeSuccess", (evt: any) => urlListeners.forEach(fn => fn(evt)));
 
     // Bind LocationConfig.html5Mode to $locationProvider.html5Mode and $sniffer.history
     services.locationConfig.html5Mode = function() {
@@ -212,18 +212,18 @@ function ng1UiRouter($locationProvider) {
   }
 }
 
-function $stateParamsFactory(ng1UiRouter) {
+function $stateParamsFactory(ng1UiRouter: any) {
   return ng1UiRouter.globals.params;
 }
 
 // The 'ui.router' ng1 module depends on 'ui.router.init' module.
 angular.module('ui.router.init', []).provider("ng1UiRouter", <any> ng1UiRouter);
 // This effectively calls $get() to init when we enter runtime
-angular.module('ui.router.init').run(['ng1UiRouter', function(ng1UiRouter) { }]);
+angular.module('ui.router.init').run(['ng1UiRouter', function(ng1UiRouter: any) { }]);
 
 // $urlMatcherFactory service and $urlMatcherFactoryProvider
 angular.module('ui.router.util').provider('$urlMatcherFactory', ['ng1UiRouterProvider', () => router.urlMatcherFactory]);
-angular.module('ui.router.util').run(['$urlMatcherFactory', function($urlMatcherFactory) { }]);
+angular.module('ui.router.util').run(['$urlMatcherFactory', function($urlMatcherFactory: any) { }]);
 
 // $urlRouter service and $urlRouterProvider
 function getUrlRouterProvider() {
@@ -235,7 +235,7 @@ function getUrlRouterProvider() {
   return router.urlRouterProvider;
 }
 angular.module('ui.router.router').provider('$urlRouter', ['ng1UiRouterProvider', getUrlRouterProvider]);
-angular.module('ui.router.router').run(['$urlRouter', function($urlRouter) { }]);
+angular.module('ui.router.router').run(['$urlRouter', function($urlRouter: any) { }]);
 
 // $state service and $stateProvider
 // $urlRouter service and $urlRouterProvider
@@ -248,10 +248,10 @@ function getStateProvider() {
   return router.stateProvider;
 }
 angular.module('ui.router.state').provider('$state', ['ng1UiRouterProvider', getStateProvider]);
-angular.module('ui.router.state').run(['$state', function($state) { }]);
+angular.module('ui.router.state').run(['$state', function($state: any) { }]);
 
 // $stateParams service
-angular.module('ui.router.state').factory('$stateParams', ['ng1UiRouter', (ng1UiRouter) =>
+angular.module('ui.router.state').factory('$stateParams', ['ng1UiRouter', (ng1UiRouter: any) =>
     ng1UiRouter.globals.params]);
 
 // $transitions service and $transitionsProvider
@@ -273,14 +273,14 @@ angular.module('ui.router').factory('$resolve', <any> resolveFactory);
 // $trace service
 angular.module("ui.router").service("$trace", () => trace);
 watchDigests.$inject = ['$rootScope'];
-export function watchDigests($rootScope) {
+export function watchDigests($rootScope: any) {
   $rootScope.$watch(function() { trace.approximateDigests++; });
 }
 angular.module("ui.router").run(watchDigests);
 
 export const getLocals = (ctx: ResolveContext) => {
   let tokens = ctx.getTokens().filter(isString);
-  let tuples = tokens.map(key => [ key, ctx.getResolvable(key).data ]);
+  let tuples = tokens.map((key: any) => [ key, ctx.getResolvable(key).data ]);
   return tuples.reduce(applyPairs, {});
 };
 

--- a/src/ng1/stateFilters.ts
+++ b/src/ng1/stateFilters.ts
@@ -10,8 +10,8 @@
  * Translates to {@link ui.router.state.$state#methods_is $state.is("stateName")}.
  */
 $IsStateFilter.$inject = ['$state'];
-export function $IsStateFilter($state) {
-  var isFilter: any = function(state, params, options) {
+export function $IsStateFilter($state: any) {
+  var isFilter: any = function(state: any, params: any, options: any) {
     return $state.is(state, params, options);
   };
   isFilter.$stateful = true;
@@ -28,8 +28,8 @@ export function $IsStateFilter($state) {
  * Translates to {@link ui.router.state.$state#methods_includes $state.includes('fullOrPartialStateName')}.
  */
 $IncludedByStateFilter.$inject = ['$state'];
-export function $IncludedByStateFilter($state) {
-  var includesFilter: any = function(state, params, options) {
+export function $IncludedByStateFilter($state: any) {
+  var includesFilter: any = function(state: any, params: any, options: any) {
     return $state.includes(state, params, options);
   };
   includesFilter.$stateful = true;

--- a/src/ng1/statebuilders/onEnterExitRetain.ts
+++ b/src/ng1/statebuilders/onEnterExitRetain.ts
@@ -15,10 +15,10 @@ import {extend} from "../../common/common";
  * When the [[StateBuilder]] builds a [[State]] object from a raw [[StateDeclaration]], this builder
  * ensures that those hooks are injectable for angular-ui-router (ng1).
  */
-export const getStateHookBuilder = (hookName) =>
-function stateHookBuilder(state: State, parentFn): TransitionStateHookFn {
+export const getStateHookBuilder = (hookName: any) =>
+function stateHookBuilder(state: State, parentFn: any): TransitionStateHookFn {
   let hook = state[hookName];
-  function decoratedNg1Hook(trans: Transition, inj: IInjectorService, state): HookResult {
+  function decoratedNg1Hook(trans: Transition, inj: IInjectorService, state: any): HookResult {
     let resolveContext = new ResolveContext(trans.treeChanges().to);
     return services.$injector.invoke(hook, this, extend({ $state$: state }, getLocals(resolveContext)));
   }

--- a/src/ng1/statebuilders/views.ts
+++ b/src/ng1/statebuilders/views.ts
@@ -13,7 +13,7 @@ import {TemplateFactory} from "../templateFactory";
 import {ResolveContext} from "../../resolve/resolveContext";
 import {Resolvable} from "../../resolve/resolvable";
 
-export const ng1ViewConfigFactory = (path, view) => new Ng1ViewConfig(path, view);
+export const ng1ViewConfigFactory = (path: any, view: any) => new Ng1ViewConfig(path, view);
 
 /**
  * This is a [[StateBuilder.builder]] function for angular1 `views`.
@@ -31,13 +31,13 @@ export function ng1ViewsBuilder(state: State) {
       nonCompKeys = tplKeys.concat(ctrlKeys),
       allKeys = compKeys.concat(nonCompKeys);
 
-  let views = {}, viewsObject = state.views || {"$default": pick(state, allKeys)};
+  let views: { [key: string]: any; } = {}, viewsObject = state.views || {"$default": pick(state, allKeys)};
 
-  forEach(viewsObject, function (config: Ng1ViewDeclaration, name) {
+  forEach(viewsObject, function (config: Ng1ViewDeclaration, name: any) {
     // Account for views: { "": { template... } }
     name = name || "$default";
     // Account for views: { header: "headerComponent" }
-    if (isString(config)) config = { component: <string> config };
+    if (isString(config)) config = { component: <any> config };
     if (!Object.keys(config).length) return;
 
     // Configure this view for routing to an angular 1.5+ style .component (or any directive, really)
@@ -47,10 +47,10 @@ export function ng1ViewsBuilder(state: State) {
       }
 
       // Dynamically build a template like "<component-name input1='::$resolve.foo'></component-name>"
-      config.templateProvider = ['$injector', function($injector) {
-        const resolveFor = key => config.bindings && config.bindings[key] || key;
+      config.templateProvider = ['$injector', function($injector: any) {
+        const resolveFor = (key: any) => config.bindings && config.bindings[key] || key;
         const prefix = angular.version.minor >= 3 ? "::" : "";
-        const attributeTpl = input => {
+        const attributeTpl = (input: any) => {
           var attrName = kebobString(input.name);
           var resolveName = resolveFor(input.name);
           if (input.type === '@')
@@ -80,20 +80,20 @@ export function ng1ViewsBuilder(state: State) {
 
 // for ng 1.2 style, process the scope: { input: "=foo" }
 // for ng 1.3 through ng 1.5, process the component's bindToController: { input: "=foo" } object
-const scopeBindings = bindingsObj => Object.keys(bindingsObj || {})
+const scopeBindings = (bindingsObj: any) => Object.keys(bindingsObj || {})
       .map(key => [key, /^([=<@])[?]?(.*)/.exec(bindingsObj[key])])        // [ 'input', [ '=foo', '=', 'foo' ] ]
       .filter(tuple => isDefined(tuple) && isDefined(tuple[1]))             // skip malformed values
       .map(tuple => ({ name: tuple[1][2] || tuple[0], type: tuple[1][1] }));// { name: ('foo' || 'input'), type: '=' }
 
 // Given a directive definition, find its object input attributes
 // Use different properties, depending on the type of directive (component, bindToController, normal)
-const getBindings = def => {
+const getBindings = (def: any) => {
   if (isObject(def.bindToController)) return scopeBindings(def.bindToController);
   return <any> scopeBindings(def.scope);
 };
 
 // Gets all the directive(s)' inputs ('@', '=', and '<')
-function getComponentInputs($injector, name) {
+function getComponentInputs($injector: any, name: any) {
   let cmpDefs = $injector.get(name + "Directive"); // could be multiple
   if (!cmpDefs || !cmpDefs.length) throw new Error(`Unable to find component named '${name}'`);
   return cmpDefs.map(getBindings).reduce(unnestR, []);
@@ -122,7 +122,7 @@ export class Ng1ViewConfig implements ViewConfig {
       controller: $q.when(this.getController(context))
     };
 
-    return $q.all(promises).then((results) => {
+    return $q.all(promises).then((results: any) => {
       trace.traceViewServiceEvent("Loaded", this);
       this.controller = results.controller;
       this.template = results.template;
@@ -138,7 +138,7 @@ export class Ng1ViewConfig implements ViewConfig {
     return !!(this.viewDecl.template || this.viewDecl.templateUrl || this.viewDecl.templateProvider);
   }
 
-  getTemplate(params, $factory, context: ResolveContext) {
+  getTemplate(params: any, $factory: any, context: ResolveContext) {
     return $factory.fromConfig(this.viewDecl, params, context);
   }
 

--- a/src/ng1/templateFactory.ts
+++ b/src/ng1/templateFactory.ts
@@ -41,7 +41,7 @@ export class TemplateFactory {
    * @return {string|object} The template html as a string, or a promise for that 
    * string.
    */
-  fromString(template: (string|Function), params?) {
+  fromString(template: (string|Function), params?: any) {
     return isFunction(template) ? (<any> template)(params) : template;
   };
 

--- a/src/ng1/viewScroll.ts
+++ b/src/ng1/viewScroll.ts
@@ -39,12 +39,12 @@ function $ViewScrollProvider() {
    * If you prefer to rely on `$anchorScroll` to scroll the view to the anchor,
    * this can be enabled by calling {@link ui.router.state.$uiViewScrollProvider#methods_useAnchorScroll `$uiViewScrollProvider.useAnchorScroll()`}.
    */
-  this.$get = ['$anchorScroll', '$timeout', function ($anchorScroll, $timeout) {
+  this.$get = ['$anchorScroll', '$timeout', function ($anchorScroll: any, $timeout: any) {
     if (useAnchorScroll) {
       return $anchorScroll;
     }
 
-    return function ($element) {
+    return function ($element: any) {
       return $timeout(function () {
         $element[0].scrollIntoView();
       }, 0, false);

--- a/src/ng2/directives/uiSref.ts
+++ b/src/ng2/directives/uiSref.ts
@@ -11,7 +11,7 @@ import {extend} from "../../common/common";
 @Directive({ selector: 'a[uiSref]' })
 export class AnchorUiSref {
   constructor(public _el: ElementRef, public _renderer: Renderer) { }
-  update(href) {
+  update(href: any) {
     this._renderer.setElementProperty(this._el.nativeElement, 'href', href);
   }
 }
@@ -72,9 +72,9 @@ export class UiSref {
       @Optional() private _anchorUiSref: AnchorUiSref
   ) { }
 
-  set "uiSref"(val) { this.state = val; this.update(); }
-  set "uiParams"(val) { this.params = val; this.update(); }
-  set "uiOptions"(val) { this.options = val; this.update(); }
+  set "uiSref"(val: any) { this.state = val; this.update(); }
+  set "uiParams"(val: any) { this.params = val; this.update(); }
+  set "uiOptions"(val: any) { this.options = val; this.update(); }
 
   ngOnInit() {
     this.update();

--- a/src/ng2/directives/uiSrefActive.ts
+++ b/src/ng2/directives/uiSrefActive.ts
@@ -33,10 +33,10 @@ import {UiSrefStatus, SrefStatus} from "./uiSrefStatus";
 export class UiSrefActive {
 
   private _classes: string[] = [];
-  @Input('uiSrefActive') set active(val) { this._classes = val.split("\s+")};
+  @Input('uiSrefActive') set active(val: any) { this._classes = val.split("\s+")};
 
   private _classesEq: string[] = [];
-  @Input('uiSrefActiveEq') set activeEq(val) { this._classesEq = val.split("\s+")};
+  @Input('uiSrefActiveEq') set activeEq(val: any) { this._classesEq = val.split("\s+")};
 
   constructor(uiSrefStatus: UiSrefStatus, rnd: Renderer, @Host() host: ElementRef) {
     uiSrefStatus.uiSrefStatus.subscribe((next: SrefStatus) => {

--- a/src/ng2/directives/uiSrefStatus.ts
+++ b/src/ng2/directives/uiSrefStatus.ts
@@ -40,7 +40,7 @@ export interface SrefStatus {
  */
 @Directive({ selector: '[uiSrefStatus],[uiSrefActive],[uiSrefActiveEq]' })
 export class UiSrefStatus {
-  private _deregisterHook;
+  private _deregisterHook: any;
 
   // current statuses of the state/params the uiSref directive is linking to
   @Output("uiSrefStatus") uiSrefStatus = new EventEmitter<SrefStatus>(false);
@@ -56,7 +56,7 @@ export class UiSrefStatus {
               private _globals: Globals,
               private _stateService: StateService,
               public sref: UiSref) {
-    this._deregisterHook = transitionService.onStart({}, $transition$ => this.processTransition($transition$));
+    this._deregisterHook = transitionService.onStart({}, ($transition$: any) => this.processTransition($transition$));
   }
 
   ngOnInit() {

--- a/src/ng2/directives/uiView.ts
+++ b/src/ng2/directives/uiView.ts
@@ -27,28 +27,28 @@ export interface ParentUiViewInject {
 
 
 /** @hidden */
-const ng2ComponentInputs = (ng2CompClass) => {
+const ng2ComponentInputs = (ng2CompClass: any) => {
   /** Get "@Input('foo') _foo" inputs */
-  let props = Reflect['getMetadata']('propMetadata', ng2CompClass);
+  let props = (<any>Reflect)['getMetadata']('propMetadata', ng2CompClass);
   let _props = Object.keys(props || {})
   // -> { string, anno[] } tuples
       .map(key => ({ key, annoArr: props[key] }))
       // -> to { string, anno } tuples
-      .reduce((acc, tuple) => acc.concat(tuple.annoArr.map(anno => ({ key: tuple.key, anno }))), [])
+      .reduce((acc, tuple) => acc.concat(tuple.annoArr.map((anno: any) => ({ key: tuple.key, anno }))), [])
       // Only Inputs
       .filter(tuple => tuple.anno instanceof InputMetadata)
       // If they have a bindingPropertyName, i.e. "@Input('foo') _foo", then foo, else _foo
       .map(tuple => ({ token: tuple.anno.bindingPropertyName || tuple.key, prop: tuple.key }));
 
   /** Get "inputs: ['foo']" inputs */
-  let inputs = Reflect['getMetadata']('annotations', ng2CompClass)
+  let inputs = (<any>Reflect)['getMetadata']('annotations', ng2CompClass)
   // Find the ComponentMetadata class annotation
-      .filter(x => x instanceof ComponentMetadata && !!x.inputs)
+      .filter((x: any) => x instanceof ComponentMetadata && !!x.inputs)
       // Get the .inputs string array
-      .map(x => x.inputs)
+      .map((x: any) => x.inputs)
       // Flatten
-      .reduce((acc, arr) => acc.concat(arr), [])
-      .map(input => ({ token: input, prop: input }));
+      .reduce((acc: any, arr: any) => acc.concat(arr), [])
+      .map((input: any) => ({ token: input, prop: input }));
 
   return _props.concat(inputs);
 };
@@ -123,7 +123,7 @@ const ng2ComponentInputs = (ng2CompClass) => {
 })
 export class UiView {
   @Input('name') name: string;
-  @Input('ui-view') set _name(val) { this.name = val; }
+  @Input('ui-view') set _name(val: any) { this.name = val; }
   componentRef: ComponentRef<any>;
   deregister: Function;
   uiViewData: any = {};
@@ -182,8 +182,8 @@ export class UiView {
 
     // Map resolves to "useValue providers"
     let context = new ResolveContext(config.path);
-    let resolvables = context.getTokens().map(token => context.getResolvable(token)).filter(r => r.resolved);
-    let rawProviders = resolvables.map(r => ({ provide: r.token, useValue: r.data }));
+    let resolvables = context.getTokens().map((token: any) => context.getResolvable(token)).filter((r: any) => r.resolved);
+    let rawProviders = resolvables.map((r: any) => ({ provide: r.token, useValue: r.data }));
     rawProviders.push({ provide: UiView.PARENT_INJECT, useValue: { context: config.viewDecl.$context, fqn: uiViewData.fqn } });
 
     // Get the component class from the view declaration. TODO: allow promises?
@@ -197,7 +197,7 @@ export class UiView {
       // TODO: wire uiCanExit and uiOnParamsChanged callbacks
 
       let bindings = viewDecl['bindings'] || {};
-      var addResolvable = tuple => ({
+      var addResolvable = (tuple: any) => ({
         prop: tuple.prop,
         resolvable: context.getResolvable(bindings[tuple.prop] || tuple.token)
       });

--- a/src/ng2/interface.ts
+++ b/src/ng2/interface.ts
@@ -311,7 +311,7 @@ export interface Ng2Component {
    * });
    * ```
    */
-  uiOnParamsChanged(newValues: any, $transition$: Transition);
+  uiOnParamsChanged(newValues: any, $transition$: Transition): any;
 
   /**
    * This callback is called when the view's state is about to be exited.
@@ -338,5 +338,5 @@ export interface Ng2Component {
    *
    * @return a value, or a promise for a value.
    */
-  uiCanExit();
+  uiCanExit(): any;
 }

--- a/src/ng2/location.ts
+++ b/src/ng2/location.ts
@@ -47,7 +47,7 @@ export class UiRouterLocation {
       return queryString.split("&").map(kv => splitOnEquals(kv)).reduce(applyPairs, {});
     };
 
-    loc.url = (url) => {
+    loc.url = (url: any) => {
       if(isDefined(url)) {
         let split = splitOnQuestionMark(url);
         locSt.pushState(null, null, split[0], split[1]);
@@ -59,13 +59,13 @@ export class UiRouterLocation {
       console.log(new Error('$location.replace() not impl'))
     };
 
-    loc.onChange = cb => locSt.onPopState(cb);
+    loc.onChange = (cb: any) => locSt.onPopState(cb);
 
     let locCfg = <any> services.locationConfig;
 
-    locCfg.port = () => null;
-    locCfg.protocol = () => null;
-    locCfg.host = () => null;
+    locCfg.port = () => null as any;
+    locCfg.protocol = () => null as any;
+    locCfg.host = () => null as any;
     locCfg.baseHref = () => locSt.getBaseHref();
     locCfg.html5Mode = () => !this.isHashBang;
     locCfg.hashPrefix = (newprefix: string): string => {

--- a/src/ng2/providers.ts
+++ b/src/ng2/providers.ts
@@ -120,5 +120,5 @@ export const UIROUTER_PROVIDERS: ProviderLike[] = [
 
   { provide: Globals, useFactory: (r: UiRouter) => { return r.globals; }, deps: [UiRouter]},
 
-  { provide: UiView.PARENT_INJECT, useFactory: (r: StateRegistry) => { return { fqn: null, context: r.root() } }, deps: [StateRegistry]}
+  { provide: UiView.PARENT_INJECT, useFactory: (r: StateRegistry) => { return { fqn: null as any, context: r.root() } }, deps: [StateRegistry]}
 ];

--- a/src/ng2/statebuilders/views.ts
+++ b/src/ng2/statebuilders/views.ts
@@ -17,9 +17,9 @@ import {ViewService} from "../../view/view";
  * applies the state-level configuration to a view named `$default`.
  */
 export function ng2ViewsBuilder(state: State) {
-  let views = {}, viewsObject = state.views || {"$default": pick(state, "component")};
+  let views: { [key: string]: any; } = {}, viewsObject = state.views || {"$default": pick(state, "component")};
 
-  forEach(viewsObject, function (config, name) {
+  forEach(viewsObject, function (config: any, name: any) {
     name = name || "$default"; // Account for views: { "": { template... } }
     if (Object.keys(config).length == 0) return;
 

--- a/src/params/param.ts
+++ b/src/params/param.ts
@@ -9,13 +9,13 @@ import {ParamType} from "./type";
 import {paramTypes} from "./paramTypes";
 
 let hasOwn = Object.prototype.hasOwnProperty;
-let isShorthand = cfg => ["value", "type", "squash", "array", "dynamic"].filter(hasOwn.bind(cfg || {})).length === 0;
+let isShorthand = (cfg: any) => ["value", "type", "squash", "array", "dynamic"].filter(hasOwn.bind(cfg || {})).length === 0;
 
 export enum DefType {
   PATH, SEARCH, CONFIG
 }
 
-function unwrapShorthand(cfg) {
+function unwrapShorthand(cfg: any) {
   cfg = isShorthand(cfg) && { value: cfg } || cfg;
 
   return extend(cfg, {
@@ -23,7 +23,7 @@ function unwrapShorthand(cfg) {
   });
 }
 
-function getType(cfg, urlType, location, id) {
+function getType(cfg: any, urlType: any, location: any, id: any) {
   if (cfg.type && urlType && urlType.name !== 'string') throw new Error(`Param '${id}' has two type configurations.`);
   if (cfg.type && urlType && urlType.name === 'string' && paramTypes.type(cfg.type)) return paramTypes.type(cfg.type);
   if (urlType) return urlType;
@@ -34,7 +34,7 @@ function getType(cfg, urlType, location, id) {
 /**
  * returns false, true, or the squash value to indicate the "default parameter url squash policy".
  */
-function getSquashPolicy(config, isOptional) {
+function getSquashPolicy(config: any, isOptional: any) {
   let squash = config.squash;
   if (!isOptional || squash === false) return false;
   if (!isDefined(squash) || squash == null) return matcherConfig.defaultSquashPolicy();
@@ -42,8 +42,8 @@ function getSquashPolicy(config, isOptional) {
   throw new Error(`Invalid squash policy: '${squash}'. Valid policies: false, true, or arbitrary string`);
 }
 
-function getReplace(config, arrayMode, isOptional, squash) {
-  let replace, configuredKeys, defaultPolicy = [
+function getReplace(config: any, arrayMode: any, isOptional: any, squash: any) {
+  let replace: any, configuredKeys: any, defaultPolicy = [
     {from: "", to: (isOptional || arrayMode ? undefined : "")},
     {from: null, to: (isOptional || arrayMode ? undefined : "")}
   ];
@@ -105,7 +105,7 @@ export class Param {
       return defaultValue;
     };
 
-    const $replace = (val) => {
+    const $replace = (val: any) => {
       let replacement: any = map(filter(this.replace, propEq('from', val)), prop("to"));
       return replacement.length ? replacement[0] : val;
     };
@@ -150,7 +150,7 @@ export class Param {
     return new Param(id, type, config, DefType.SEARCH);
   }
 
-  static values(params: Param[], values = {}): RawParams {
+  static values(params: Param[], values: { [key: string]: any; } = {}): RawParams {
     return <RawParams> params.map(param => [param.id, param.value(values[param.id])]).reduce(applyPairs, {});
   }
 
@@ -165,7 +165,7 @@ export class Param {
    *
    * @returns any Param objects whose values were different between values1 and values2
    */
-  static changed(params: Param[], values1 = {}, values2 = {}): Param[] {
+  static changed(params: Param[], values1: { [key: string]: any; } = {}, values2: { [key: string]: any; } = {}): Param[] {
     return params.filter(param => !param.type.equals(values1[param.id], values2[param.id]));
   }
 
@@ -183,7 +183,7 @@ export class Param {
   }
 
   /** Returns true if a the parameter values are valid, according to the Param definitions */
-  static validates(params: Param[], values = {}): boolean {
+  static validates(params: Param[], values: { [key: string]: any; } = {}): boolean {
     return params.map(param => param.validates(values[param.id])).reduce(allTrueR, true);
   }
 }

--- a/src/params/paramTypes.ts
+++ b/src/params/paramTypes.ts
@@ -9,8 +9,8 @@ import {ParamType} from "./type";
 // If the slashes are simply URLEncoded, the browser can choose to pre-decode them,
 // and bidirectional encoding/decoding fails.
 // Tilde was chosen because it's not a RFC 3986 section 2.2 Reserved Character
-function valToString(val) { return val != null ? val.toString().replace(/~/g, "~~").replace(/\//g, "~2F") : val; }
-function valFromString(val) { return val != null ? val.toString().replace(/~2F/g, "/").replace(/~~/g, "~") : val; }
+function valToString(val: any) { return val != null ? val.toString().replace(/~/g, "~~").replace(/\//g, "~2F") : val; }
+function valFromString(val: any) { return val != null ? val.toString().replace(/~2F/g, "/").replace(/~~/g, "~") : val; }
 
 export class ParamTypes {
   types: any;
@@ -23,7 +23,7 @@ export class ParamTypes {
       decode: valFromString,
       is: is(String),
       pattern: /.*/,
-      equals: (a, b) => a == b // allow coersion for null/undefined/""
+      equals: (a: any, b: any) => a == b // allow coersion for null/undefined/""
     },
     "string": {
       encode: valToString,
@@ -33,31 +33,31 @@ export class ParamTypes {
     },
     "int": {
       encode: valToString,
-      decode(val) { return parseInt(val, 10); },
-      is(val) { return isDefined(val) && this.decode(val.toString()) === val; },
+      decode(val: any) { return parseInt(val, 10); },
+      is(val: any) { return isDefined(val) && this.decode(val.toString()) === val; },
       pattern: /-?\d+/
     },
     "bool": {
-      encode: val => val && 1 || 0,
-      decode: val => parseInt(val, 10) !== 0,
+      encode: (val: any) => val && 1 || 0,
+      decode: (val: any) => parseInt(val, 10) !== 0,
       is: is(Boolean),
       pattern: /0|1/
     },
     "date": {
-      encode(val) {
+      encode(val: any) {
         return !this.is(val) ? undefined : [
           val.getFullYear(),
           ('0' + (val.getMonth() + 1)).slice(-2),
           ('0' + val.getDate()).slice(-2)
         ].join("-");
       },
-      decode(val) {
+      decode(val: any) {
         if (this.is(val)) return val;
         let match = this.capture.exec(val);
         return match ? new Date(match[1], match[2] - 1, match[3]) : undefined;
       },
-      is: (val) => val instanceof Date && !isNaN(val.valueOf()),
-      equals(l, r) {
+      is: (val: any) => val instanceof Date && !isNaN(val.valueOf()),
+      equals(l: any, r: any) {
         return ['getFullYear', 'getMonth', 'getDate']
             .reduce((acc, fn) => acc && l[fn]() === r[fn](), true)
       },
@@ -81,11 +81,11 @@ export class ParamTypes {
 
   constructor() {
     // Register default types. Store them in the prototype of this.types.
-    const makeType = (definition, name) => new ParamType(extend({ name }, definition));
+    const makeType = (definition: any, name: any) => new ParamType(extend({ name }, definition));
     this.types = inherit(map(this.defaultTypes, makeType), {});
   }
 
-  type(name, definition?: any, definitionFn?: Function) {
+  type(name: any, definition?: any, definitionFn?: Function) {
     if (!isDefined(definition)) return this.types[name];
     if (this.types.hasOwnProperty(name)) throw new Error(`A type named '${name}' has already been defined.`);
 

--- a/src/params/stateParams.ts
+++ b/src/params/stateParams.ts
@@ -14,8 +14,8 @@ export class StateParams {
    * @param {Object} $current Internal definition of object representing the current state.
    * @param {Object} $to Internal definition of object representing state to transition to.
    */
-  $inherit(newParams, $current, $to) {
-    let parents = ancestors($current, $to), parentParams, inherited = {}, inheritList = [];
+  $inherit(newParams: any, $current: any, $to: any) {
+    let parents = ancestors($current, $to), parentParams: any, inherited: { [key: string]: any; } = {}, inheritList: any[] = [];
 
     for (let i in parents) {
       if (!parents[i] || !parents[i].params) continue;
@@ -30,5 +30,7 @@ export class StateParams {
     }
     return extend({}, inherited, newParams);
   };
+
+  [key: string]: any;
 }
 

--- a/src/params/type.ts
+++ b/src/params/type.ts
@@ -6,12 +6,12 @@ import {ParamTypeDefinition} from "./interface";
 /**
  * Wraps up a `ParamType` object to handle array values.
  */
-function ArrayType(type, mode) {
+function ArrayType(type: any, mode: any) {
   // Wrap non-array value as array
-  function arrayWrap(val): any[] { return isArray(val) ? val : (isDefined(val) ? [ val ] : []); }
+  function arrayWrap(val: any): any[] { return isArray(val) ? val : (isDefined(val) ? [ val ] : []); }
 
   // Unwrap array value for "auto" mode. Return undefined for empty array.
-  function arrayUnwrap(val) {
+  function arrayUnwrap(val: any) {
     switch (val.length) {
       case 0: return undefined;
       case 1: return mode === "auto" ? val[0] : val;
@@ -20,8 +20,8 @@ function ArrayType(type, mode) {
   }
 
   // Wraps type (.is/.encode/.decode) functions to operate on each value of an array
-  function arrayHandler(callback, allTruthyMode?: boolean) {
-    return function handleArray(val) {
+  function arrayHandler(callback: any, allTruthyMode?: boolean) {
+    return function handleArray(val: any) {
       if (isArray(val) && val.length === 0) return val;
       let arr = arrayWrap(val);
       let result = map(arr, callback);
@@ -30,8 +30,8 @@ function ArrayType(type, mode) {
   }
 
   // Wraps type (.equals) functions to operate on each value of an array
-  function arrayEqualsHandler(callback) {
-    return function handleArray(val1, val2) {
+  function arrayEqualsHandler(callback: any) {
+    return function handleArray(val1: any, val2: any) {
       let left = arrayWrap(val1), right = arrayWrap(val2);
       if (left.length !== right.length) return false;
       for (let i = 0; i < left.length; i++) {
@@ -112,7 +112,7 @@ export class ParamType implements ParamTypeDefinition {
   }
 
   /** Given an encoded string, or a decoded object, returns a decoded object */
-  $normalize(val) {
+  $normalize(val: any) {
     return this.is(val) ? val : this.decode(val);
   }
 
@@ -126,9 +126,9 @@ export class ParamType implements ParamTypeDefinition {
    * - url: "/path?queryParam=1 will create $stateParams.queryParam: 1
    * - url: "/path?queryParam=1&queryParam=2 will create $stateParams.queryParam: [1, 2]
    */
-  $asArray(mode, isSearch) {
+  $asArray(mode: any, isSearch: any) {
     if (!mode) return this;
     if (mode === "auto" && !isSearch) throw new Error("'auto' array mode is for query parameters only");
-    return new ArrayType(this, mode);
+    return new (<any>ArrayType)(this, mode);
   }
 }

--- a/src/path/node.ts
+++ b/src/path/node.ts
@@ -30,7 +30,7 @@ export class PathNode {
   constructor(state: PathNode);
   /** Creates a new (empty) PathNode for a State */
   constructor(state: State);
-  constructor(state) {
+  constructor(state: any) {
     if (state instanceof PathNode) {
       let node: PathNode = state;
       this.state = node.state;
@@ -42,7 +42,7 @@ export class PathNode {
       this.state = state;
       this.paramSchema = state.parameters({ inherit: false });
       this.paramValues = {};
-      this.resolvables = state.resolvables.map(res => res.clone());
+      this.resolvables = state.resolvables.map((res: any) => res.clone());
     }
   }
 
@@ -63,7 +63,7 @@ export class PathNode {
    * equal to the state and param values for this PathNode
    */
   equals(node: PathNode, keys = this.paramSchema.map(prop('id'))): boolean {
-    const paramValsEq = key => this.parameter(key).type.equals(this.paramValues[key], node.paramValues[key]);
+    const paramValsEq = (key: any) => this.parameter(key).type.equals(this.paramValues[key], node.paramValues[key]);
     return this.state === node.state && keys.map(paramValsEq).reduce(allTrueR, true);
   }
 
@@ -79,7 +79,7 @@ export class PathNode {
    * Nodes are compared using their state property and parameter values.
    */
   static matching(pathA: PathNode[], pathB: PathNode[]): PathNode[] {
-    let matching = [];
+    let matching: any[] = [];
 
     for (let i = 0; i < pathA.length && i < pathB.length; i++) {
       let a = pathA[i], b = pathB[i];

--- a/src/path/pathFactory.ts
+++ b/src/path/pathFactory.ts
@@ -97,7 +97,7 @@ export class PathFactory {
    */
   static treeChanges(fromPath: PathNode[], toPath: PathNode[], reloadState: State): TreeChanges {
     let keep = 0, max = Math.min(fromPath.length, toPath.length);
-    const staticParams = (state) => state.parameters({ inherit: false }).filter(not(prop('dynamic'))).map(prop('id'));
+    const staticParams = (state: any) => state.parameters({ inherit: false }).filter(not(prop('dynamic'))).map(prop('id'));
     const nodesMatch = (node1: PathNode, node2: PathNode) => node1.equals(node2, staticParams(node1.state));
 
     while (keep < max && fromPath[keep].state !== reloadState && nodesMatch(fromPath[keep], toPath[keep])) {

--- a/src/resolve/resolvable.ts
+++ b/src/resolve/resolvable.ts
@@ -113,7 +113,7 @@ export class Resolvable implements ResolvableLiteral {
             r.get(resolveContext, trans)));
 
     // Invokes the resolve function passing the resolved dependencies as arguments
-    const invokeResolveFn = resolvedDeps =>
+    const invokeResolveFn = (resolvedDeps: any) =>
         this.resolveFn.apply(null, resolvedDeps);
 
     /**
@@ -124,7 +124,7 @@ export class Resolvable implements ResolvableLiteral {
      * - then calls toPromise() (this triggers subscribe() and thus fetches)
      * - Waits for the promise, then return the cached observable (not the first emitted value).
      */
-    const waitForRx = observable$ => {
+    const waitForRx = (observable$: any) => {
       let cached = observable$.cache();
       return cached.toPromise().then(() => cached);
     };
@@ -132,10 +132,10 @@ export class Resolvable implements ResolvableLiteral {
     // If the resolve policy is RXWAIT, wait for the observable to emit something. otherwise pass through.
     let node: PathNode = resolveContext.findNode(this);
     let state: State = node && node.state;
-    let maybeWaitForRx = this.getPolicy(state).async === "RXWAIT" ? waitForRx : x => x;
+    let maybeWaitForRx = this.getPolicy(state).async === "RXWAIT" ? waitForRx : (x: any) => x;
 
     // After the final value has been resolved, update the state of the Resolvable
-    const applyResolvedValue = resolvedValue => {
+    const applyResolvedValue = (resolvedValue: any) => {
       this.data = resolvedValue;
       this.resolved = true;
       trace.traceResolvableResolved(this, trans);

--- a/src/resolve/resolveContext.ts
+++ b/src/resolve/resolveContext.ts
@@ -41,7 +41,7 @@ export class ResolveContext {
    * Gets the last Resolvable that matches the token in this context, or undefined.
    * Throws an error if it doesn't exist in the ResolveContext
    */
-  getResolvable(token): Resolvable {
+  getResolvable(token: any): Resolvable {
     var matching = this._path.map(node => node.resolvables)
         .reduce(unnestR, [])
         .filter((r: Resolvable) => r.token === token);
@@ -129,7 +129,7 @@ export class ResolveContext {
     return services.$q.all(promises);
   }
 
-  injector(): { get(any): any } {
+  injector(): { get(any: any): any } {
     
     let get = (token: any) => {
       var resolvable = this.getResolvable(token);
@@ -158,7 +158,7 @@ export class ResolveContext {
         .reduce((acc, node) => acc.concat(node.resolvables), []) //all of subpath's resolvables
         .filter(res => res !== resolvable); // filter out the `resolvable` argument
 
-    const getDependency = token => {
+    const getDependency = (token: any) => {
       let matching = availableResolvables.filter(r => r.token === token);
       if (matching.length) return tail(matching);
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -43,5 +43,7 @@ export class UiRouter {
     this.globals.$current = this.stateRegistry.root();
     this.globals.current = this.globals.$current.self;
   }
+  
+  [key: string]: any;
 }
 

--- a/src/state/interface.ts
+++ b/src/state/interface.ts
@@ -525,6 +525,8 @@ export interface StateDeclaration {
    * @deprecated define individual parameters as [[ParamDeclaration.dynamic]]
    */
   reloadOnSearch?: boolean;
+
+  [key: string]: any;
 }
 
 export interface HrefOptions {

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -261,7 +261,7 @@ export class StateProvider {
    * To create a parent/child state use a dot, e.g. "about.sales", "home.newest".
    * @param {object} definition State configuration object.
    */
-  state(name, definition) {
+  state(name: any, definition: any) {
     if (isObject(name)) {
       definition = name;
     } else {
@@ -293,4 +293,6 @@ export class StateProvider {
   onInvalid(callback: Function) {
     this.invalidCallbacks.push(callback);
   }
+
+  [key: string]: any;
 }

--- a/src/state/stateBuilder.ts
+++ b/src/state/stateBuilder.ts
@@ -20,7 +20,7 @@ const parseUrl = (url: string): any => {
   return { val: root ? url.substring(1) : url, root };
 };
 
-export type BuilderFunction = (state: State, parent?) => any;
+export type BuilderFunction = (state: State, parent?: any) => any;
 
 interface Builders {
   [key: string]: BuilderFunction[];
@@ -49,13 +49,13 @@ function dataBuilder(state: State) {
   return state.data;
 }
 
-const getUrlBuilder = ($urlMatcherFactoryProvider, root) =>
+const getUrlBuilder = ($urlMatcherFactoryProvider: any, root: any) =>
 function urlBuilder(state: State) {
   let stateDec: StateDeclaration = <any> state;
   const parsed = parseUrl(stateDec.url), parent = state.parent;
   const url = !parsed ? stateDec.url : $urlMatcherFactoryProvider.compile(parsed.val, {
     params: state.params || {},
-    paramMap: function (paramConfig, isSearch) {
+    paramMap: function (paramConfig: any, isSearch: any) {
       if (stateDec.reloadOnSearch === false && isSearch) paramConfig = extend(paramConfig || {}, {dynamic: true});
       return paramConfig;
     }
@@ -66,7 +66,7 @@ function urlBuilder(state: State) {
   return (parsed && parsed.root) ? url : ((parent && parent.navigable) || root()).url.append(<UrlMatcher> url);
 };
 
-const getNavigableBuilder = (isRoot) =>
+const getNavigableBuilder = (isRoot: any) =>
 function navigableBuilder(state: State) {
   return !isRoot(state) && state.url ? state : (state.parent ? state.parent.navigable : null);
 };
@@ -131,39 +131,39 @@ function includesBuilder(state: State) {
  */
 export function resolvablesBuilder(state: State): Resolvable[] {
   /** convert a resolve: {} object to an array of tuples */
-  const obj2Tuples        = obj => Object.keys(obj || {}).map(token => ({token, val: obj[token], deps: undefined}));
+  const obj2Tuples        = (obj: any) => Object.keys(obj || {}).map(token => ({token, val: obj[token], deps: undefined}));
   /** fetch DI annotations from a function or ng1-style array */
-  const annotate          = fn  => fn.$inject || services.$injector.annotate(fn, services.$injector.strictDi);
+  const annotate          = (fn: any)  => fn.$inject || services.$injector.annotate(fn, services.$injector.strictDi);
   /** true if the object has both `token` and `resolveFn`, and is probably a [[ResolveLiteral]] */
-  const isResolveLiteral  = obj => !!(obj.token && obj.resolveFn);
+  const isResolveLiteral  = (obj: any) => !!(obj.token && obj.resolveFn);
   /** true if the object looks like a provide literal, or a ng2 Provider */
-  const isLikeNg2Provider = obj => !!((obj.provide || obj.token) && (obj.useValue || obj.useFactory || obj.useExisting || obj.useClass));
+  const isLikeNg2Provider = (obj: any) => !!((obj.provide || obj.token) && (obj.useValue || obj.useFactory || obj.useExisting || obj.useClass));
   /** true if the object looks like a tuple from obj2Tuples */
-  const isTupleFromObj    = obj => !!(obj && obj.val && (isString(obj.val) || isArray(obj.val)  || isFunction(obj.val)));
+  const isTupleFromObj    = (obj: any) => !!(obj && obj.val && (isString(obj.val) || isArray(obj.val)  || isFunction(obj.val)));
   /** extracts the token from a Provider or provide literal */
-  const token             = p => p.provide || p.token;
+  const token             = (p: any) => p.provide || p.token;
 
   /** Given a literal resolve or provider object, returns a Resolvable */
   const literal2Resolvable = pattern([
-    [prop('resolveFn'),   p => new Resolvable(token(p), p.resolveFn, p.deps, p.policy)],
-    [prop('useFactory'),  p => new Resolvable(token(p), p.useFactory, (p.deps || p.dependencies), p.policy)],
-    [prop('useClass'),    p => new Resolvable(token(p), () => new (<any>p.useClass)(), [], p.policy)],
-    [prop('useValue'),    p => new Resolvable(token(p), () => p.useValue, [], p.policy, p.useValue)],
-    [prop('useExisting'), p => new Resolvable(token(p), (x) => x, [p.useExisting], p.policy)],
+    [prop('resolveFn'),   (p: any) => new Resolvable(token(p), p.resolveFn, p.deps, p.policy)],
+    [prop('useFactory'),  (p: any) => new Resolvable(token(p), p.useFactory, (p.deps || p.dependencies), p.policy)],
+    [prop('useClass'),    (p: any) => new Resolvable(token(p), () => new (<any>p.useClass)(), [], p.policy)],
+    [prop('useValue'),    (p: any) => new Resolvable(token(p), () => p.useValue, [], p.policy, p.useValue)],
+    [prop('useExisting'), (p: any) => new Resolvable(token(p), (x: any) => x, [p.useExisting], p.policy)],
   ]);
 
   const tuple2Resolvable = pattern([
-    [pipe(prop("val"), isString),   tuple => new Resolvable(tuple.token, x => x, [ tuple.val ], tuple.policy)],
-    [pipe(prop("val"), isArray),    tuple => new Resolvable(tuple.token, tail(<any[]> tuple.val), tuple.val.slice(0, -1), tuple.policy)],
-    [pipe(prop("val"), isFunction), tuple => new Resolvable(tuple.token, tuple.val, annotate(tuple.val), tuple.policy)],
+    [pipe(prop("val"), isString),   (tuple: any) => new Resolvable(tuple.token, (x: any) => x, [ tuple.val ], tuple.policy)],
+    [pipe(prop("val"), isArray),    (tuple: any) => new Resolvable(tuple.token, tail(<any[]> tuple.val), tuple.val.slice(0, -1), tuple.policy)],
+    [pipe(prop("val"), isFunction), (tuple: any) => new Resolvable(tuple.token, tuple.val, annotate(tuple.val), tuple.policy)],
   ]);
 
-  const item2Resolvable = <(any) => Resolvable> pattern([
+  const item2Resolvable = <(any: any) => Resolvable> pattern([
     [is(Resolvable),                (r: Resolvable) => r],
     [isResolveLiteral,              literal2Resolvable],
     [isLikeNg2Provider,             literal2Resolvable],
     [isTupleFromObj,                tuple2Resolvable],
-    [val(true),                     tuple => { throw new Error("Invalid resolve value: " + stringify(tuple)) }]
+    [val(true),                     (tuple: any) => { throw new Error("Invalid resolve value: " + stringify(tuple)) }]
   ]);
 
   // If resolveBlock is already an array, use it as-is.
@@ -193,7 +193,7 @@ export class StateBuilder {
     let self = this;
 
     const root = () => matcher.find("");
-    const isRoot = (state) => state.name === "";
+    const isRoot = (state: any) => state.name === "";
 
     function parentBuilder(state: State) {
       if (isRoot(state)) return null;
@@ -239,7 +239,7 @@ export class StateBuilder {
 
     builders[name] = array;
     builders[name].push(fn);
-    return () => builders[name].splice(builders[name].indexOf(fn, 1)) && null;
+    return () => builders[name].splice(builders[name].indexOf(fn, 1)) && null as any;
   }
 
   /**
@@ -256,20 +256,20 @@ export class StateBuilder {
 
     for (let key in builders) {
       if (!builders.hasOwnProperty(key)) continue;
-      let chain = builders[key].reduce((parentFn, step: BuilderFunction) => (_state) => step(_state, parentFn), noop);
+      let chain = builders[key].reduce((parentFn: any, step: BuilderFunction) => (_state) => step(_state, parentFn), noop);
       state[key] = chain(state);
     }
     return state;
   }
 
-  parentName(state) {
+  parentName(state: any) {
     let name = state.name || "";
     if (name.indexOf('.') !== -1) return name.substring(0, name.lastIndexOf('.'));
     if (!state.parent) return "";
     return isString(state.parent) ? state.parent : state.parent.name;
   }
 
-  name(state) {
+  name(state: any) {
     let name = state.name;
     if (name.indexOf('.') !== -1 || !state.parent) return name;
 

--- a/src/state/stateObject.ts
+++ b/src/state/stateObject.ts
@@ -89,7 +89,7 @@ export class State {
     return this.parent && this.parent.root() || this;
   }
 
-  parameters(opts?): Param[] {
+  parameters(opts?: any): Param[] {
     opts = defaults(opts, { inherit: true });
     let inherited = opts.inherit && this.parent && this.parent.parameters() || [];
     return inherited.concat(values(this.params));
@@ -106,4 +106,6 @@ export class State {
   toString() {
     return this.fqn();
   }
+
+  [key: string]: any;
 }

--- a/src/state/stateQueueManager.ts
+++ b/src/state/stateQueueManager.ts
@@ -13,7 +13,7 @@ export class StateQueueManager {
   constructor(
       public states: { [key: string]: State; },
       public builder: StateBuilder,
-      public $urlRouterProvider) {
+      public $urlRouterProvider: any) {
     this.queue = [];
   }
 
@@ -39,9 +39,9 @@ export class StateQueueManager {
     return state;
   }
 
-  flush($state) {
+  flush($state: any) {
     let {queue, states, builder} = this;
-    let result, state, orphans = [], orphanIdx, previousQueueLength = {};
+    let result: any, state: any, orphans: any[] = [], orphanIdx: any, previousQueueLength: { [key: string]: any; } = {};
 
     while (queue.length > 0) {
       state = queue.shift();
@@ -72,16 +72,16 @@ export class StateQueueManager {
     return states;
   }
 
-  autoFlush($state) {
+  autoFlush($state: any) {
     this.$state = $state;
     this.flush($state);
   }
 
-  attachRoute($state, state) {
+  attachRoute($state: any, state: any) {
     let {$urlRouterProvider} = this;
     if (state[abstractKey] || !state.url) return;
 
-    $urlRouterProvider.when(state.url, ['$match', '$stateParams', function ($match, $stateParams) {
+    $urlRouterProvider.when(state.url, ['$match', '$stateParams', function ($match: any, $stateParams: any) {
       if ($state.$current.navigable !== state || !equalForKeys($match, $stateParams)) {
         $state.transitionTo(state, $match, { inherit: true, location: false });
       }

--- a/src/state/stateRegistry.ts
+++ b/src/state/stateRegistry.ts
@@ -17,7 +17,7 @@ export class StateRegistry {
   private builder: StateBuilder;
   stateQueue: StateQueueManager;
 
-  constructor(urlMatcherFactory: UrlMatcherFactory, urlRouterProvider) {
+  constructor(urlMatcherFactory: UrlMatcherFactory, urlRouterProvider: any) {
     this.matcher = new StateMatcher(this.states);
     this.builder = new StateBuilder(this.matcher, urlMatcherFactory);
     this.stateQueue = new StateQueueManager(this.states, this.builder, urlRouterProvider);

--- a/src/state/stateService.ts
+++ b/src/state/stateService.ts
@@ -57,7 +57,7 @@ export class StateService {
 
     const invokeCallback = (callback: Function) => $q.when($injector.invoke(callback, null, { $to$, $from$ }));
 
-    const checkForRedirect = (result) => {
+    const checkForRedirect = (result: any) => {
       if (!(result instanceof TargetState)) {
         return;
       }
@@ -74,7 +74,7 @@ export class StateService {
     function invokeNextCallback() {
       let nextCallback = callbackQueue.dequeue();
       if (nextCallback === undefined) return Rejection.invalid($to$.error()).toPromise();
-      return invokeCallback(nextCallback).then(checkForRedirect).then(result => result || invokeNextCallback());
+      return invokeCallback(nextCallback).then(checkForRedirect).then((result: any) => result || invokeNextCallback());
     }
 
     return invokeNextCallback();
@@ -285,7 +285,7 @@ export class StateService {
      * no error occurred.  Likewise, the transition.run() promise may be rejected because of
      * a Redirect, but the transitionTo() promise is chained to the new Transition's promise.
      */
-    const rejectedTransitionHandler = (transition) => (error) => {
+    const rejectedTransitionHandler: (transition: any) => (error: any) => any = (transition: any) => (error: any) => {
       if (error instanceof Rejection) {
         if (error.type === RejectType.IGNORED) {
           router.urlRouter.update();

--- a/src/transition/hookRegistry.ts
+++ b/src/transition/hookRegistry.ts
@@ -27,7 +27,7 @@ import {State} from "../state/stateObject";
 export function matchState(state: State, criterion: HookMatchCriterion) {
   let toMatch = isString(criterion) ? [criterion] : criterion;
 
-  function matchGlobs(_state) {
+  function matchGlobs(_state: any) {
     let globStrings = <string[]> toMatch;
     for (let i = 0; i < globStrings.length; i++) {
       let glob = Glob.fromString(globStrings[i]);
@@ -72,7 +72,7 @@ export class EventHook implements IEventHook {
   matches(treeChanges: TreeChanges): IMatchingNodes {
     let mc = this.matchCriteria, _matchingNodes = EventHook._matchingNodes;
 
-    let matches = {
+    let matches: { [key: string]: PathNode[]; } = {
       to: _matchingNodes([tail(treeChanges.to)], mc.to),
       from: _matchingNodes([tail(treeChanges.from)], mc.from),
       exiting: _matchingNodes(treeChanges.exiting, mc.exiting),
@@ -85,7 +85,7 @@ export class EventHook implements IEventHook {
         .map(prop => matches[prop])
         .reduce(allTrueR, true);
 
-    return allMatched ? matches : null;
+    return allMatched ? (matches as any) : null;
   }
 }
 
@@ -146,4 +146,6 @@ export class HookRegistry implements IHookRegistry {
   onSuccess = makeHookRegistrationFn(this._transitionEvents, "onSuccess");
   /** @inheritdoc */
   onError   = makeHookRegistrationFn(this._transitionEvents, "onError");
+
+  [key: string]: any;
 }

--- a/src/transition/interface.ts
+++ b/src/transition/interface.ts
@@ -655,6 +655,8 @@ export interface IHookRegistry {
    * ```
    */
   getHooks(hookName: string): IEventHook[];
+
+  [key: string]: any;
 }
 
 /** A predicate type which takes a [[State]] and returns a boolean */
@@ -737,6 +739,7 @@ export interface IMatchingNodes {
   exiting: PathNode[];
   retained: PathNode[];
   entering: PathNode[];
+  [key: string]: PathNode[];
 }
 
 /**

--- a/src/transition/rejectFactory.ts
+++ b/src/transition/rejectFactory.ts
@@ -14,14 +14,14 @@ export class Rejection {
   detail: string;
   redirected: boolean;
 
-  constructor(type, message?, detail?) {
+  constructor(type: any, message?: any, detail?: any) {
     this.type = type;
     this.message = message;
     this.detail = detail;
   }
 
   toString() {
-    const detailString = d => d && d.toString !== Object.prototype.toString ? d.toString() : stringify(d);
+    const detailString = (d: any) => d && d.toString !== Object.prototype.toString ? d.toString() : stringify(d);
     let type = this.type, message = this.message, detail = detailString(this.detail);
     return `TransitionRejection(type: ${type}, message: ${message}, detail: ${detail})`;
   }
@@ -31,7 +31,7 @@ export class Rejection {
   }
 
   /** Returns true if the obj is a rejected promise created from the `asPromise` factory */
-  static isTransitionRejectionPromise(obj) {
+  static isTransitionRejectionPromise(obj: any) {
     return obj && (typeof obj.then === 'function') && obj._transitionRejection instanceof Rejection;
   }
 

--- a/src/transition/transition.ts
+++ b/src/transition/transition.ts
@@ -253,7 +253,7 @@ export class Transition implements IHookRegistry {
    */
   getResolveValue(token: (any|any[])): (any|any[]) {
     let resolveContext = new ResolveContext(this._treeChanges.to);
-    const getData = token => {
+    const getData = (token: any) => {
       var resolvable = resolveContext.getResolvable(token);
       if (resolvable === undefined) {
         throw new Error("Dependency Injection token not found: ${stringify(token)}");
@@ -478,7 +478,7 @@ export class Transition implements IHookRegistry {
       runSynchronousHooks(hookBuilder.getOnSuccessHooks(), true);
     };
 
-    const transitionError = (error) => {
+    const transitionError = (error: any) => {
       trace.traceError(error, this);
       this.success = false;
       this._deferred.reject(error);
@@ -529,7 +529,7 @@ export class Transition implements IHookRegistry {
     let fromStateOrName = this.from();
     let toStateOrName = this.to();
 
-    const avoidEmptyHash = (params) =>
+    const avoidEmptyHash = (params: any) =>
       (params["#"] !== null && params["#"] !== undefined) ? params : omit(params, "#");
 
     // (X) means the to state is invalid.

--- a/src/transition/transitionHook.ts
+++ b/src/transition/transitionHook.ts
@@ -55,7 +55,7 @@ export class TransitionHook {
    *
    * A hook can return false, a redirect (TargetState), or a promise (which may resolve to false or a redirect)
    */
-  handleHookResult(hookResult): Promise<any> {
+  handleHookResult(hookResult: any): Promise<any> {
     if (!isDefined(hookResult)) return undefined;
 
     /**
@@ -67,9 +67,9 @@ export class TransitionHook {
       // If the hook returns false, abort the current Transition
       [eq(false),         () => Rejection.aborted("Hook aborted transition").toPromise()],
       // If the hook returns a Transition, halt the current Transition and redirect to that Transition.
-      [is(TargetState),   (target) => Rejection.redirected(target).toPromise()],
+      [is(TargetState),   (target: any) => Rejection.redirected(target).toPromise()],
       // A promise was returned, wait for the promise and then chain another hookHandler
-      [isPromise,         (promise) => promise.then(this.handleHookResult.bind(this))]
+      [isPromise,         (promise: any) => promise.then(this.handleHookResult.bind(this))]
     ]);
 
     let transitionResult = mapHookResult(hookResult);
@@ -93,7 +93,7 @@ export class TransitionHook {
    * Returns a promise chain composed of any promises returned from each hook.invokeStep() call
    */
   static runSynchronousHooks(hooks: TransitionHook[], swallowExceptions: boolean = false): Promise<any> {
-    let results = [];
+    let results: any[] = [];
     for (let i = 0; i < hooks.length; i++) {
       try {
         results.push(hooks[i].invokeHook(true));

--- a/src/transition/transitionService.ts
+++ b/src/transition/transitionService.ts
@@ -110,7 +110,7 @@ export class TransitionService implements IHookRegistry {
   getHooks  : (hookName: string) => IEventHook[];
 
   /** @hidden */
-  private _defaultErrorHandler: ((_error) => void) = function $defaultErrorHandler($error$) {
+  private _defaultErrorHandler: ((_error: any) => void) = function $defaultErrorHandler($error$) {
     if ($error$ instanceof Error) {
       console.error($error$);
     }
@@ -127,7 +127,7 @@ export class TransitionService implements IHookRegistry {
    * @param handler a global error handler function
    * @returns the current global error handler
    */
-  defaultErrorHandler(handler?: (error) => void): (error) => void {
+  defaultErrorHandler(handler?: (error: any) => void): (error: any) => void {
     return this._defaultErrorHandler = handler || this._defaultErrorHandler;
   }
 
@@ -144,4 +144,6 @@ export class TransitionService implements IHookRegistry {
   create(fromPath: PathNode[], targetState: TargetState): Transition {
     return new Transition(fromPath, targetState, this._router);
   }
+
+  [key: string]: any;
 }

--- a/src/url/urlMatcher.ts
+++ b/src/url/urlMatcher.ts
@@ -32,7 +32,7 @@ function quoteRegExp(string: any, param?: any) {
 }
 
 /** @hidden */
-const memoizeTo = (obj, prop, fn) => obj[prop] = obj[prop] || fn();
+const memoizeTo = (obj: any, prop: any, fn: any) => obj[prop] = obj[prop] || fn();
 
 /**
  * Matches URLs against patterns.
@@ -141,16 +141,16 @@ export class UrlMatcher {
     //    \{(?:[^{}\\]+|\\.)*\}          - a matched set of curly braces containing other atoms
     let placeholder = /([:*])([\w\[\]]+)|\{([\w\[\]]+)(?:\:\s*((?:[^{}\\]+|\\.|\{(?:[^{}\\]+|\\.)*\})+))?\}/g,
         searchPlaceholder = /([:]?)([\w\[\].-]+)|\{([\w\[\].-]+)(?:\:\s*((?:[^{}\\]+|\\.|\{(?:[^{}\\]+|\\.)*\})+))?\}/g,
-        last = 0, m, patterns = [];
+        last = 0, m: any, patterns: any[] = [];
 
-    const checkParamErrors = (id) => {
+    const checkParamErrors = (id: any) => {
       if (!UrlMatcher.nameValidator.test(id)) throw new Error(`Invalid parameter name '${id}' in pattern '${pattern}'`);
       if (find(this._params, propEq('id', id))) throw new Error(`Duplicate parameter name '${id}' in pattern '${pattern}'`);
     };
 
     // Split into static segments separated by path parameter placeholders.
     // The number of segments is always 1 more than the number of parameters.
-    const matchDetails = (m, isSearch) => {
+    const matchDetails = (m: any, isSearch: any) => {
       // IE[78] returns '' for unmatched groups instead of null
       let id = m[2] || m[3], regexp = isSearch ? m[4] : m[4] || (m[1] === '*' ? '.*' : null);
 
@@ -165,7 +165,7 @@ export class UrlMatcher {
       };
     }
 
-    let p, segment;
+    let p: any, segment: any;
 
     while ((m = placeholder.exec(pattern))) {
       p = matchDetails(m, false);
@@ -218,7 +218,7 @@ export class UrlMatcher {
    */
   append(url: UrlMatcher): UrlMatcher {
     this._children.push(url);
-    forEach(url._cache, (val, key) => url._cache[key] = isArray(val) ? [] : null);
+    forEach(url._cache, (val: any, key: any) => (<any>url._cache)[key] = isArray(val) ? [] : null as any);
     url._cache.path = this._cache.path.concat(this);
     return url;
   }
@@ -278,7 +278,7 @@ export class UrlMatcher {
         pathParams:   Param[] = allParams.filter(param => !param.isSearch()),
         searchParams: Param[] = allParams.filter(param => param.isSearch()),
         nPathSegments  = this._cache.path.concat(this).map(urlm => urlm._segments.length - 1).reduce((a, x) => a + x),
-        values = {};
+        values: { [key: string]: any; } = {};
 
     if (nPathSegments !== match.length - 1)
       throw new Error(`Unbalanced capture group in route '${this.pattern}'`);
@@ -304,7 +304,7 @@ export class UrlMatcher {
       if (isDefined(value)) value = param.type.decode(value);
       values[param.id] = param.value(value);
     }
-    forEach(searchParams, param => {
+    forEach(searchParams, (param: any) => {
       let value = search[param.id];
       for (let j = 0; j < param.replace.length; j++) {
         if (param.replace[j].from === value) value = param.replace[j].to;
@@ -358,7 +358,7 @@ export class UrlMatcher {
    * @returns Returns `true` if `params` validates, otherwise `false`.
    */
   validates(params: RawParams): boolean {
-    const validParamVal = (param: Param, val) => !param || param.validates(val);
+    const validParamVal = (param: Param, val: any) => !param || param.validates(val);
     return pairs(params || {}).map(([key, val]) => validParamVal(this.parameter(key), val)).reduce(allTrueR, true);
   }
 
@@ -378,7 +378,7 @@ export class UrlMatcher {
    * @param values  the values to substitute for the parameters in this pattern.
    * @returns the formatted URL (path and optionally search part).
    */
-  format(values = {}) {
+  format(values: { [key: string]: any; } = {}) {
     if (!this.validates(values)) return null;
 
     // Build the full path of UrlMatchers (including all parent UrlMatchers)
@@ -447,7 +447,7 @@ export class UrlMatcher {
   }
 
   /** @hidden */
-  static encodeDashes(str) { // Replace dashes with encoded "\-"
+  static encodeDashes(str: any) { // Replace dashes with encoded "\-"
     return encodeURIComponent(str).replace(/-/g, c => `%5C%${c.charCodeAt(0).toString(16).toUpperCase()}`);
   }
 
@@ -455,7 +455,7 @@ export class UrlMatcher {
   static pathSegmentsAndParams(matcher: UrlMatcher) {
     let staticSegments = matcher._segments;
     let pathParams = matcher._params.filter(p => p.location === DefType.PATH);
-    return arrayTuples(staticSegments, pathParams.concat(undefined)).reduce(unnestR, []).filter(x => x !== "" && isDefined(x));
+    return arrayTuples(staticSegments, pathParams.concat(undefined)).reduce(unnestR, []).filter((x: any) => x !== "" && isDefined(x));
   }
 
   /** @hidden Given a matcher, return an array with the matcher's query params */

--- a/src/url/urlMatcherFactory.ts
+++ b/src/url/urlMatcherFactory.ts
@@ -85,7 +85,7 @@ export class UrlMatcherFactory {
     if (!isObject(object)) return false;
     let result = true;
 
-    forEach(UrlMatcher.prototype, (val, name) => {
+    forEach(UrlMatcher.prototype, (val: any, name: any) => {
       if (isFunction(val)) result = result && (isDefined(object[name]) && isFunction(object[name]));
     });
     return result;

--- a/src/url/urlRouter.ts
+++ b/src/url/urlRouter.ts
@@ -10,20 +10,20 @@ import {StateParams} from "../params/stateParams";
 let $location = services.location;
 
 /** @hidden Returns a string that is a prefix of all strings matching the RegExp */
-function regExpPrefix(re) {
+function regExpPrefix(re: any) {
   let prefix = /^\^((?:\\[^a-zA-Z0-9]|[^\\\[\]\^$*+?.()|{}]+)*)/.exec(re.source);
   return (prefix != null) ? prefix[1].replace(/\\(.)/g, "$1") : '';
 }
 
 /** @hidden Interpolates matched values into a String.replace()-style pattern */
-function interpolate(pattern, match) {
-  return pattern.replace(/\$(\$|\d{1,2})/, function (m, what) {
+function interpolate(pattern: any, match: any) {
+  return pattern.replace(/\$(\$|\d{1,2})/, function (m: any, what: any) {
     return match[what === '$' ? 0 : Number(what)];
   });
 }
 
 /** @hidden */
-function handleIfMatch($injector, $stateParams, handler, match) {
+function handleIfMatch($injector: any, $stateParams: any, handler: any, match: any) {
   if (!match) return false;
   let result = $injector.invoke(handler, handler, { $match: match, $stateParams: $stateParams });
   return isDefined(result) ? result : true;
@@ -43,7 +43,7 @@ function appendBasePath(url: string, isHtml5: boolean, absolute: boolean): strin
 function update(rules: Function[], otherwiseFn: Function, evt?: any) {
   if (evt && evt.defaultPrevented) return;
 
-  function check(rule) {
+  function check(rule: any) {
     let handled = rule(services.$injector, $location);
 
     if (!handled) return false;
@@ -53,7 +53,7 @@ function update(rules: Function[], otherwiseFn: Function, evt?: any) {
     }
     return true;
   }
-  let n = rules.length, i;
+  let n = rules.length, i: any;
 
   for (i = 0; i < n; i++) {
     if (check(rules[i])) return;
@@ -70,9 +70,9 @@ function update(rules: Function[], otherwiseFn: Function, evt?: any) {
  */
 export class UrlRouterProvider {
   /** @hidden */
-  rules = [];
+  rules: any[] = [];
   /** @hidden */
-  otherwiseFn: ($injector, $location) => string;
+  otherwiseFn: ($injector: any, $location: any) => string;
   /** @hidden */
   interceptDeferred = false;
 
@@ -118,7 +118,7 @@ export class UrlRouterProvider {
    *
    * @return [[$urlRouterProvider]] (`this`)
    */
-  rule(rule: ($injector, $location) => string): UrlRouterProvider {
+  rule(rule: ($injector: any, $location: any) => string): UrlRouterProvider {
     if (!isFunction(rule)) throw new Error("'rule' must be a function");
     this.rules.push(rule);
     return this;
@@ -151,7 +151,7 @@ export class UrlRouterProvider {
    *
    * @return {object} `$urlRouterProvider` - `$urlRouterProvider` instance
    */
-  otherwise(rule: string | (($injector, $location) => string)): UrlRouterProvider {
+  otherwise(rule: string | (($injector: any, $location: any) => string)): UrlRouterProvider {
     if (!isFunction(rule) && !isString(rule)) throw new Error("'rule' must be a string or function");
     this.otherwiseFn = isString(rule) ? () => rule : rule;
     return this;
@@ -197,7 +197,7 @@ export class UrlRouterProvider {
    */
   when(what: (RegExp|UrlMatcher|string), handler: string|IInjectable) {
     let {$urlMatcherFactory, $stateParams} = this;
-    let redirect, handlerIsString = isString(handler);
+    let redirect: any, handlerIsString = isString(handler);
 
     // @todo Queue this
     if (isString(what)) what = $urlMatcherFactory.compile(<string> what);
@@ -205,8 +205,8 @@ export class UrlRouterProvider {
     if (!handlerIsString && !isFunction(handler) && !isArray(handler))
       throw new Error("invalid 'handler' in when()");
 
-    let strategies = {
-      matcher: function (_what, _handler) {
+    let strategies: { [key: string]: any } = {
+      matcher: function (_what: any, _handler: any) {
         if (handlerIsString) {
           redirect = $urlMatcherFactory.compile(_handler);
           _handler = ['$match', redirect.format.bind(redirect)];
@@ -217,12 +217,12 @@ export class UrlRouterProvider {
           prefix: isString(_what.prefix) ? _what.prefix : ''
         });
       },
-      regex: function (_what, _handler) {
+      regex: function (_what: any, _handler: any) {
         if (_what.global || _what.sticky) throw new Error("when() RegExp must not be global or sticky");
 
         if (handlerIsString) {
           redirect = _handler;
-          _handler = ['$match', ($match) => interpolate(redirect, $match)];
+          _handler = ['$match', ($match: any) => interpolate(redirect, $match)];
         }
         return extend(function () {
           return handleIfMatch(services.$injector, $stateParams, _handler, _what.exec($location.path()));
@@ -232,7 +232,7 @@ export class UrlRouterProvider {
       }
     };
 
-    let check = {
+    let check: { [key: string]: any } = {
       matcher: $urlMatcherFactory.isMatcher(what),
       regex: what instanceof RegExp
     };
@@ -275,10 +275,12 @@ export class UrlRouterProvider {
    * @param defer Indicates whether to defer location change interception. Passing
    *        no parameter is equivalent to `true`.
    */
-  deferIntercept(defer) {
+  deferIntercept(defer: any) {
     if (defer === undefined) defer = true;
     this.interceptDeferred = defer;
   };
+
+  [key: string]: any;
 }
 
 export class UrlRouter {
@@ -331,13 +333,13 @@ export class UrlRouter {
    * This causes [[UrlRouter]] to start listening for changes to the URL, if it wasn't already listening.
    */
   listen(): Function {
-    return this.listener = this.listener || $location.onChange(evt => update(this.urlRouterProvider.rules, this.urlRouterProvider.otherwiseFn, evt));
+    return this.listener = this.listener || $location.onChange((evt: any) => update(this.urlRouterProvider.rules, this.urlRouterProvider.otherwiseFn, evt));
   }
 
   /**
    * Internal API.
    */
-  update(read?) {
+  update(read?: any) {
     if (read) {
       this.location = $location.url();
       return;

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -8,8 +8,8 @@ import {PathNode} from "../path/node";
 import {ActiveUiView, ViewContext, ViewConfig} from "./interface";
 import {_ViewDeclaration} from "../state/interface";
 
-const match = (obj1, ...keys) =>
-    (obj2) => keys.reduce((memo, key) => memo && obj1[key] === obj2[key], true);
+const match = (obj1: any, ...keys: any[]) =>
+    (obj2: any) => keys.reduce((memo, key) => memo && obj1[key] === obj2[key], true);
 
 export type ViewConfigFactory = (path: PathNode[], decl: _ViewDeclaration) => ViewConfig|ViewConfig[];
 
@@ -19,12 +19,12 @@ export type ViewConfigFactory = (path: PathNode[], decl: _ViewDeclaration) => Vi
 export class ViewService {
   private uiViews: ActiveUiView[] = [];
   private viewConfigs: ViewConfig[] = [];
-  private _rootContext;
+  private _rootContext: any;
   private _viewConfigFactories: { [key: string]: ViewConfigFactory } = {};
 
   constructor() { }
 
-  rootContext(context) {
+  rootContext(context: any) {
     return this._rootContext = context || this._rootContext;
   };
 
@@ -148,9 +148,9 @@ export class ViewService {
     }
 
     // Given a depth function, returns a compare function which can return either ascending or descending order
-    const depthCompare = curry((depthFn, posNeg, left, right) => posNeg * (depthFn(left) - depthFn(right)));
+    const depthCompare = curry((depthFn: any, posNeg: any, left: any, right: any) => posNeg * (depthFn(left) - depthFn(right)));
 
-    const matchingConfigPair = uiView => {
+    const matchingConfigPair = (uiView: any) => {
       let matchingConfigs = this.viewConfigs.filter(matches(uiView));
       if (matchingConfigs.length > 1)
         matchingConfigs.sort(depthCompare(viewConfigDepth, -1)); // descending
@@ -179,7 +179,7 @@ export class ViewService {
   registerUiView(uiView: ActiveUiView) {
     trace.traceViewServiceUiViewEvent("-> Registering", uiView);
     let uiViews = this.uiViews;
-    const fqnMatches = uiv => uiv.fqn === uiView.fqn;
+    const fqnMatches = (uiv: any) => uiv.fqn === uiView.fqn;
     if (uiViews.filter(fqnMatches).length)
       trace.traceViewServiceUiViewEvent("!!!! duplicate uiView named:", uiView);
 

--- a/tsconfig-ng2.json
+++ b/tsconfig-ng2.json
@@ -10,7 +10,8 @@
     "target": "es5",
     "outDir": "build/es5",
     "declaration": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "noImplicitAny": true
   },
   "files": [
     "src/ng2.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "target": "es5",
     "outDir": "build/es5",
     "declaration": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "noImplicitAny": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This resolves issue https://github.com/angular-ui/ui-router/issues/2693.

I know the issue had been marked as WontFix but i've created this PR given that users of the latest router will have to be on TypeScript 2.0 (which hasn't yet shipped) and have specific a tsconfig option set in order to use the ui-router (usage of `noImplicitAny` is pretty commonplace). That's a real shame and a slight barrier to entry. 

For the most part it was just a case of taking a trip through the code and adding to method signatures an `any` annotation per parameter where there is no annotation at all at present.  If you decided to upgrade the types to something more specific over time that would be completely open to you. 

Whilst working on this I noticed there were some invalid references to the `stateEvents.ts` file in `files.js` and `Gruntfile.js`.  I've fixed these so they point to the `legacy` subfolder.

