### PR TITLE
fix(Resolve): prevent RXWAIT from waiting for the observable to complete

### DIFF
--- a/src/resolve/resolvable.ts
+++ b/src/resolve/resolvable.ts
@@ -46,7 +46,7 @@ export class Resolvable implements ResolvableLiteral {
   /** This constructor creates a new Resolvable from the plain old [[ResolvableLiteral]] javascript object */
   constructor(resolvable: ResolvableLiteral)
 
-  /** 
+  /**
    * This constructor creates a new `Resolvable`
    *
    * @example
@@ -125,8 +125,8 @@ export class Resolvable implements ResolvableLiteral {
      * - Waits for the promise, then return the cached observable (not the first emitted value).
      */
     const waitForRx = (observable$: any) => {
-      let cached = observable$.cache();
-      return cached.toPromise().then(() => cached);
+      let cached = observable$.cache(1);
+      return cached.take(1).toPromise().then(() => cached);
     };
 
     // If the resolve policy is RXWAIT, wait for the observable to emit something. otherwise pass through.


### PR DESCRIPTION
The RXWAIT resolve policy is supposed to wait for the resolved observable to begin emitting values, and then provide the observable.  It accomplishes this by first `cache()`ing the observable and then waiting on the result of `toPromise`. However,  RxJS `toPromise` only resolves the promise when the stream completes, not when the first value is emitted as desired.  Adding `take(1)` before `toPromise` will cause the stream to complete after 1 value is emitted, at what point the original stream can be returned.

Also, the `cache()` without a buffer size will cause all old results to be replayed to new subscribers.  Setting a buffer size of 1 will cause only the most recent emitted value to be replayed.