### PR TITLE
fix(transitionHook): Prevent queued hookFn to be called if deregistered

### DIFF
--- a/src/transition/hookBuilder.ts
+++ b/src/transition/hookBuilder.ts
@@ -98,7 +98,7 @@ export class HookBuilder {
        return matchingNodes.map(node => {
          let _options = extend({ bind: hook.bind, traceData: { hookType, context: node} }, this.baseHookOptions, options);
          let state = _options.stateHook ? node.state : null;
-         let transitionHook = new TransitionHook(this.transition, state, hook.callback, _options);
+         let transitionHook = new TransitionHook(this.transition, state, hook, _options);
          return <HookTuple> { hook, node, transitionHook };
        });
     };

--- a/src/transition/hookRegistry.ts
+++ b/src/transition/hookRegistry.ts
@@ -49,12 +49,14 @@ export class EventHook implements IEventHook {
   matchCriteria: HookMatchCriteria;
   priority: number;
   bind: any;
+  _deregistered: boolean;
 
   constructor(matchCriteria: HookMatchCriteria, callback: HookFn, options: HookRegOptions = <any>{}) {
     this.callback = callback;
     this.matchCriteria = extend({ to: true, from: true, exiting: true, retained: true, entering: true }, matchCriteria);
     this.priority = options.priority || 0;
     this.bind = options.bind || null;
+    this._deregistered = false;
   }
 
   private static _matchingNodes(nodes: PathNode[], criterion: HookMatchCriterion): PathNode[] {
@@ -99,6 +101,7 @@ function makeHookRegistrationFn(hooks: ITransitionEvents, name: string): IHookRe
     hooks[name].push(eventHook);
 
     return function deregisterEventHook() {
+      eventHook._deregistered = true;
       removeFrom(hooks[name])(eventHook);
     };
   };

--- a/src/transition/interface.ts
+++ b/src/transition/interface.ts
@@ -762,4 +762,5 @@ export interface IEventHook {
   priority?: number;
   bind?: any;
   matches:  (treeChanges: TreeChanges) => IMatchingNodes;
+  _deregistered: boolean;
 }

--- a/test/core/hookBuilderSpec.ts
+++ b/test/core/hookBuilderSpec.ts
@@ -62,7 +62,7 @@ describe('HookBuilder:', function() {
     expect(typeof callback).toBe('function')
   });
 
-  const getFn = x => x['hookFn'];
+  const getFn = x => x['eventHook']['callback'];
 
   describe('HookMatchCriteria', function() {
 


### PR DESCRIPTION
Fix a bug where queued hooks are called even if they are deregistered (#2928)