### PR TITLE
Fixed broken template literal syntax in `getResolveValue`.

### DIFF
--- a/src/transition/transition.ts
+++ b/src/transition/transition.ts
@@ -1,4 +1,5 @@
 /** @module transition */ /** for typedoc */
+import {stringify} from "../common/strings";
 import {trace} from "../common/trace";
 import {services} from "../common/coreservices";
 import {
@@ -235,7 +236,7 @@ export class Transition implements IHookRegistry {
     const getData = (token: any) => {
       var resolvable = resolveContext.getResolvable(token);
       if (resolvable === undefined) {
-        throw new Error("Dependency Injection token not found: ${stringify(token)}");
+        throw new Error(`Dependency Injection token not found: ${stringify(token)}`);
       }
       return resolvable.data;
     };


### PR DESCRIPTION
The thrown Error `"Dependency Injection token not found: ${stringify(token)}"` needs back ticks as well as the `stringify` function to be imported. 

Plunkr: http://embed.plnkr.co/1PNtxj674kHsXAxJIiAz/ (open console to see uncaught exception with bug)