### PR TITLE
ui-sref-active support a class match a group state

### DIFF
--- a/src/ng1/directives/stateDirectives.ts
+++ b/src/ng1/directives/stateDirectives.ts
@@ -348,6 +348,12 @@ function $StateRefActiveDirective($state: StateService, $stateParams: Obj, $inte
             var ref = parseStateRef(stateOrName, $state.current.name);
             addState(ref.state, $scope.$eval(ref.paramExpr), activeClass);
           }
+          else if(isArray(stateOrName)) {
+                  forEach(stateOrName, function(value, key) {
+                      var ref = parseStateRef(value, $state.current.name);
+                      addState(ref.state, $scope.$eval(ref.paramExpr), activeClass);
+                  });
+                }
         });
       }
 


### PR DESCRIPTION
support like this:

`
<li><a ui-sref="data.salesman" ui-sref-active="{'text-primary': ['data.salesman.*', 'data.salesmanInfo.*']}">sales</a></li>
`