### PR TITLE
fix(common): Remove `url()` from LocationService interface

### DIFF
--- a/src/common/coreservices.ts
+++ b/src/common/coreservices.ts
@@ -59,7 +59,6 @@ export interface CoreServices {
 
 export interface LocationServices {
   setUrl(newurl: string, replace?: boolean): void;
-  url(): string;
   path(): string;
   search(): string;
   hash(): string;


### PR DESCRIPTION
- `LocationService.url()` has been deprecated in favour of `setUrl()`,
  but this interface had not been fully updated.