### PR TITLE
fix(urlMatcherFactory): fix tilde edge case with "string" encoding

### DIFF
--- a/src/params/paramTypes.ts
+++ b/src/params/paramTypes.ts
@@ -10,8 +10,8 @@ import {ParamTypeDefinition} from "./interface";
 // If the slashes are simply URLEncoded, the browser can choose to pre-decode them,
 // and bidirectional encoding/decoding fails.
 // Tilde was chosen because it's not a RFC 3986 section 2.2 Reserved Character
-function valToString(val: any) { return val != null ? val.toString().replace(/~/g, "~~").replace(/\//g, "~2F") : val; }
-function valFromString(val: string) { return val != null ? val.toString().replace(/~2F/g, "/").replace(/~~/g, "~") : val; }
+function valToString(val: any) { return val != null ? val.toString().replace(/(~|\/)/g, m => ({'~':'~~', '/':'~2F'}[m])) : val; }
+function valFromString(val: string) { return val != null ? val.toString().replace(/(~~|~2F)/g, m => ({'~~':'~', '~2F':'/'}[m])) : val; }
 
 export class ParamTypes {
   types: any;

--- a/test/ng1/urlMatcherFactorySpec.js
+++ b/test/ng1/urlMatcherFactorySpec.js
@@ -111,9 +111,11 @@ describe("UrlMatcher", function () {
 
     expect(matcher1.format({ foo: "abc" })).toBe('/abc');
     expect(matcher1.format({ foo: "~abc" })).toBe('/~~abc');
+    expect(matcher1.format({ foo: "~2F" })).toBe('/~~2F');
 
     expect(matcher1.exec('/abc').foo).toBe("abc");
     expect(matcher1.exec('/~~abc').foo).toBe("~abc");
+    expect(matcher1.exec('/~~2F').foo).toBe("~2F");
   });
 
   describe("snake-case parameters", function() {


### PR DESCRIPTION
Hello,

I noticed that "~2F" in a param value would be encoded as "~~2F" and then decoded as "~/" ([plunk](http://plnkr.co/edit/Nu2WgFTL36dQnetRByA6?p=preview)). I fixed this so now the encoding/decoding are symmetrical. I think this use case was the reason for encoding "~", and the decoding issue was an oversight.

Note: The problem was in the decode function (valFromString), but I also refactored the encode function (valToString) so that the functions stay easy to read as a pair.

Let me know what you think. If you like it, I also prepared a [branch](https://github.com/angular-ui/ui-router/compare/legacy...cvn:fix-tilde-encoding-legacy) that ports the changes to legacy.