### PR TITLE
fix(urlMatcherFactory): fix tilde edge case with "string" encoding

### DIFF
--- a/src/urlMatcherFactory.js
+++ b/src/urlMatcherFactory.js
@@ -595,8 +595,8 @@ function $UrlMatcherFactory() {
   // If the slashes are simply URLEncoded, the browser can choose to pre-decode them,
   // and bidirectional encoding/decoding fails.
   // Tilde was chosen because it's not a RFC 3986 section 2.2 Reserved Character
-  function valToString(val) { return val != null ? val.toString().replace(/~/g, "~~").replace(/\//g, "~2F") : val; }
-  function valFromString(val) { return val != null ? val.toString().replace(/~2F/g, "/").replace(/~~/g, "~") : val; }
+  function valToString(val) { return val != null ? val.toString().replace(/(~|\/)/g, function (m) { return {'~':'~~', '/':'~2F'}[m]; }) : val; }
+  function valFromString(val) { return val != null ? val.toString().replace(/(~~|~2F)/g, function (m) { return {'~~':'~', '~2F':'/'}[m]; }) : val; }
 
   var $types = {}, enqueue = true, typeQueue = [], injector, defaultTypes = {
     "string": {

--- a/test/urlMatcherFactorySpec.js
+++ b/test/urlMatcherFactorySpec.js
@@ -92,9 +92,11 @@ describe("UrlMatcher", function () {
 
     expect(matcher1.format({ foo: "abc" })).toBe('/abc');
     expect(matcher1.format({ foo: "~abc" })).toBe('/~~abc');
+    expect(matcher1.format({ foo: "~2F" })).toBe('/~~2F');
 
     expect(matcher1.exec('/abc').foo).toBe("abc");
     expect(matcher1.exec('/~~abc').foo).toBe("~abc");
+    expect(matcher1.exec('/~~2F').foo).toBe("~2F");
   });
 
   describe("snake-case parameters", function() {


### PR DESCRIPTION
makes it possible to bidirectionally encode/decode "~2F"