### PR TITLE
doc(UrlMatcher): RegExp and `string` encoding interaction

### DIFF
--- a/src/url/urlMatcher.ts
+++ b/src/url/urlMatcher.ts
@@ -53,6 +53,9 @@ const memoizeTo = (obj: Obj, prop: string, fn: Function) =>
  * (`/somePath/{param:[a-zA-Z0-9]+}`) in a curly brace placeholder.
  * The regexp must match for the url to be matched.
  * Should the regexp itself contain curly braces, they must be in matched pairs or escaped with a backslash.
+ * Note that a RegExp parameter will encode its value with `string` ParamType encoding: "/" as "~2F", and "~" as "~~". 
+ * When matching these characters, use the encoded versions in the regexp.
+ * See issue [#2540](https://github.com/angular-ui/ui-router/issues/2540) for more information.
  *
  * - *Custom parameter types* may also be specified after a colon (`/somePath/{param:int}`)
  * in curly brace parameters.  See [[UrlMatcherFactory.type]] for more information.


### PR DESCRIPTION
Hello,

I added some documentation about how the tilde encoding interacts with RegExp params. It seemed to only exist in tickets and the code.

My thoughts are that there's no way to fix it so that you wouldn't need to know about the encoding, because there needs to be a way to match both real slashes and encoded slashes.

This makes the RegExp param description quite long, but I couldn't find a better place to put it.

I've also created a [branch](https://github.com/angular-ui/ui-router/compare/legacy...cvn:doc-tilde-encoding-legacy) that ports the change to legacy.

I think this should be enough to close #2540.