### PR TITLE
fix(Ng1ViewDeclaration): Make controllerProvider IInjectable

### DIFF
--- a/src/ng1/interface.ts
+++ b/src/ng1/interface.ts
@@ -360,7 +360,7 @@ export interface Ng1ViewDeclaration extends _ViewDeclaration {
    * }
    * ```
    */
-  controllerProvider?: Function;
+  controllerProvider?: IInjectable;
 
   /**
    * The scope variable name to use for resolve data.

--- a/test/ng1/stateSpec.js
+++ b/test/ng1/stateSpec.js
@@ -98,6 +98,14 @@ describe('state', function () {
           foo: function() { return 'Foo'; }
         }
       })
+      .state('dynamicController', {
+        url: "/dynamicController/:type",
+        template: "a",
+        controllerProvider: ["$stateParams", function($stateParams) {
+          ctrlName = $stateParams.type + "Controller";
+          return ctrlName;
+        }]
+      })
       .state('home.redirect', {
         url: "redir",
         onEnter: function($state) {
@@ -647,6 +655,12 @@ describe('state', function () {
       expect(template).toEqual("AcmeFooTemplate");
     }));
 
+    it('uses the controllerProvider to get controller dynamically', inject(function ($state, $q) {
+      $state.transitionTo('dynamicController', { type: "Acme" });
+      $q.flush();
+      expect(ctrlName).toEqual("AcmeController");
+    }));
+
     it('updates the location #fragment, if specified', inject(function ($state, $q, $location) {
       // html5mode disabled
       locationProvider.html5Mode(false);
@@ -1076,7 +1090,7 @@ describe('state', function () {
       var list = $state.get().sort(function(a, b) { return (a.name > b.name) - (b.name > a.name); });
       var names = ['', 'A', 'B', 'C', 'D', 'DD', 'DDDD', 'E', 'F', 'H', 'HH', 'HHH', 'ISS2101', 'OPT', 'OPT.OPT2', 'RS', 'URLLESS',
         'about', 'about.person', 'about.person.item', 'about.sidebar', 'about.sidebar.item',
-        'badParam', 'badParam2', 'dynamicTemplate', 'first', 'home', 'home.item', 'home.redirect',
+        'badParam', 'badParam2', 'dynamicController', 'dynamicTemplate', 'first', 'home', 'home.item', 'home.redirect',
         'json', 'logA', 'logA.logB', 'logA.logB.logC', 'resolveFail', 'resolveTimeout',
         'root', 'root.sub1', 'root.sub2', 'second'];
 

--- a/test/ng1/viewSpec.ts
+++ b/test/ng1/viewSpec.ts
@@ -12,8 +12,8 @@ import {PathFactory} from "../../src/path/module";
 import {ng1ViewsBuilder, ng1ViewConfigFactory} from "../../src/ng1/statebuilders/views";
 import {ViewService} from "../../src/view/view";
 import {StateMatcher, StateBuilder} from "../../src/state/module";
-
 import {State} from "../../src/state/module";
+import {Ng1StateDeclaration} from "../../src/ng1/interface";
 
 describe('view', function() {
   var scope, $compile, $injector, elem, $controllerProvider, $urlMatcherFactoryProvider;
@@ -55,14 +55,16 @@ describe('view', function() {
     let state, path: PathNode[], ctrlExpression;
     beforeEach(() => {
       ctrlExpression = null;
-      state = register({
+      const stateDeclaration: Ng1StateDeclaration = {
         name: "foo",
         template: "test",
-        controllerProvider: function (/* $stateParams, */ foo) { // todo: reimplement localized $stateParams
+        controllerProvider: ["foo", function (/* $stateParams, */ foo) { // todo: reimplement localized $stateParams
           ctrlExpression = /* $stateParams.type + */ foo + "Controller as foo";
           return ctrlExpression;
-        }
-      });
+        }]
+      };
+
+      state = register(stateDeclaration);
       let $view = new ViewService();
       $view.viewConfigFactory("ng1", ng1ViewConfigFactory);
 


### PR DESCRIPTION
Closes #3044. Changes the type of controllerProvider in Ng1ViewDeclaration to IInjectable. Adds 1 test for controller provider in ng1/stateSpec. Updates the controller handling test in ng1/viewSpec to verify that controllerProvider is IInjectable .