### PR TITLE
fix($InjectorLike) Optional generic type support

### DIFF
--- a/src/common/coreservices.ts
+++ b/src/common/coreservices.ts
@@ -41,6 +41,7 @@ export interface $QLike {
 
 export interface $InjectorLike {
   get(token: any): any;
+  get<T>(token: any): T;
   has(token: any): boolean;
   invoke(fn: IInjectable, context?: any, locals?: Obj): any;
   annotate(fn: IInjectable, strictDi?: boolean): any[];

--- a/src/common/interface.ts
+++ b/src/common/interface.ts
@@ -36,6 +36,7 @@ export interface UIInjector {
    * @return the Dependency Injection value that matches the token
    */
   get(token: any): any;
+  get<T>(token: any): T;
 
   /**
    * Asynchronously gets a value from the injector
@@ -58,6 +59,7 @@ export interface UIInjector {
    * @return a Promise for the Dependency Injection value that matches the token
    */
   getAsync(token: any): Promise<any>;
+  getAsync<T>(token: any): Promise<T>;
 
   /**
    * Gets a value from the native injector
@@ -73,4 +75,5 @@ export interface UIInjector {
    * @return the Dependency Injection value that matches the token
    */
   getNative(token: any): any;
+  getNative<T>(token: any): T;
 }


### PR DESCRIPTION
When working with Typescript, you currently need to do something like this to set type correctly:

```typescript
$urlRouterProvider.otherwise(($injector) => {
  let myService: MyService = $injector.get('myService');
  myService.doSomething();
});
```

With this change, you could instead write the above like this:

```typescript
$urlRouterProvider.otherwise(($injector) => {
  $injector
    .get<MyService>('myService')
    .doSomething();
});
```