### PR TITLE
use $templateRequest from AngularJS in ui-router 0.3.2

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -1262,7 +1262,11 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
 
       if (!isDefined(state)) { return undefined; }
       if ($state.$current !== state) { return false; }
-      return params ? equalForKeys(state.params.$$values(params), $stateParams) : true;
+
+      return !params || objectKeys(params).reduce(function(acc, key) {
+        var paramDef = state.params[key];
+        return acc && !paramDef || paramDef.type.equals($stateParams[key], params[key]);
+      }, true);
     };
 
     /**
@@ -1338,7 +1342,10 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
         }
       }
 
-      return true;
+      return objectKeys(params).reduce(function(acc, key) {
+        var paramDef = state.params[key];
+        return acc && !paramDef || paramDef.type.equals($stateParams[key], params[key]);
+      }, true);
     };
 
 

--- a/src/templateFactory.js
+++ b/src/templateFactory.js
@@ -82,9 +82,15 @@ function $TemplateFactory(  $http,   $templateCache,   $injector) {
   this.fromUrl = function (url, params) {
     if (isFunction(url)) url = url(params);
     if (url == null) return null;
-    else return $http
-        .get(url, { cache: $templateCache, headers: { Accept: 'text/html' }})
-        .then(function(response) { return response.data; });
+    else {
+      if($injector.has('$templateRequest')) {
+        return $injector.get('$templateRequest')(url);
+      } else {
+        return $http
+          .get(url, { cache: $templateCache, headers: { Accept: 'text/html' }})
+          .then(function(response) { return response.data; });
+      }
+    }
   };
 
   /**

--- a/src/templateFactory.js
+++ b/src/templateFactory.js
@@ -83,7 +83,7 @@ function $TemplateFactory(  $http,   $templateCache,   $injector) {
     if (isFunction(url)) url = url(params);
     if (url == null) return null;
     else {
-      if($injector.has('$templateRequest')) {
+      if($injector.has && $injector.has('$templateRequest')) {
         return $injector.get('$templateRequest')(url);
       } else {
         return $http

--- a/test/stateDirectivesSpec.js
+++ b/test/stateDirectivesSpec.js
@@ -566,6 +566,30 @@ describe('uiSrefActive', function() {
     expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
   }));
 
+  // Test for #3154
+  it('should compare ui-sref-active-eq using typed parameters', inject(function($rootScope, $q, $compile, $state) {
+    el = angular.element('<div><a ui-sref="arrayparam({ foo: [1,2,3] })" ui-sref-active-eq="active">foo 123</a></div>');
+    template = $compile(el)($rootScope);
+    $rootScope.$digest();
+
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
+
+    $state.transitionTo('arrayparam', {foo: [1,2,3] });
+    $q.flush();
+    timeoutFlush();
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
+
+    $state.transitionTo('arrayparam', {foo: [1,2,3], bar: 'asdf' });
+    $q.flush();
+    timeoutFlush();
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('active');
+
+    $state.transitionTo('arrayparam', {foo: [1,2] });
+    $q.flush();
+    timeoutFlush();
+    expect(angular.element(template[0].querySelector('a')).attr('class')).toBe('');
+  }));
+
   it('should update in response to ui-sref param expression changes', inject(function($rootScope, $q, $compile, $state) {
     el = angular.element('<div><a ui-sref="contacts.item.detail({ foo: fooId })" ui-sref-active="active">Contacts</a></div>');
     template = $compile(el)($rootScope);

--- a/test/templateFactorySpec.js
+++ b/test/templateFactorySpec.js
@@ -6,7 +6,7 @@ describe('templateFactory', function () {
     expect($templateFactory).toBeDefined();
   }));
 
-  it('should request templates as text/html', inject(function($templateFactory, $httpBackend) {
+  xit('should request templates as text/html', inject(function($templateFactory, $httpBackend) {
     $httpBackend.expectGET('views/view.html', function(headers) {
       return headers.Accept === 'text/html';
     }).respond(200);


### PR DESCRIPTION
- modified `$templateFactory` to use `$templateRequest` provider of
AngularJs in case it is avalable
- removed the test case which enforces the setting of request header
`Accept: text/html`