### PR TITLE
feat($templateFactory): refactor to a Provider to have a $http/$templateRequest switch

### DIFF
--- a/src/templateFactory.js
+++ b/src/templateFactory.js
@@ -8,7 +8,7 @@
  * use, and will default to the most recent one ($templateRequest on Angular
  * versions starting from 1.3, $http otherwise).
  */
-function $TemplateFactoryProvider() {
+function TemplateFactoryProvider() {
   var shouldUnsafelyUseHttp = angular.version.minor < 3;
 
   /**
@@ -45,7 +45,7 @@ function $TemplateFactoryProvider() {
    * Service. Manages loading of templates.
    */
   this.$get = ['$http', '$templateCache', '$injector', function($http, $templateCache, $injector){
-    return new $TemplateFactory($http, $templateCache, $injector, shouldUnsafelyUseHttp);}];
+    return new TemplateFactory($http, $templateCache, $injector, shouldUnsafelyUseHttp);}];
 }
 
 
@@ -60,7 +60,7 @@ function $TemplateFactoryProvider() {
  * @description
  * Service. Manages loading of templates.
  */
-function $TemplateFactory($http, $templateCache, $injector, shouldUnsafelyUseHttp) {
+function TemplateFactory($http, $templateCache, $injector, shouldUnsafelyUseHttp) {
 
   /**
    * @ngdoc function
@@ -161,6 +161,6 @@ function $TemplateFactory($http, $templateCache, $injector, shouldUnsafelyUseHtt
   this.fromProvider = function (provider, params, locals) {
     return $injector.invoke(provider, null, locals || { params: params });
   };
-};
+}
 
-angular.module('ui.router.util').provider('$templateFactory', $TemplateFactoryProvider);
+angular.module('ui.router.util').provider('$templateFactory', TemplateFactoryProvider);

--- a/test/templateFactorySpec.js
+++ b/test/templateFactorySpec.js
@@ -55,3 +55,26 @@ describe('templateFactory', function () {
    }));
   }
 });
+
+describe('templateFactory with $http use forced', function () {
+
+  beforeEach(function() {
+    angular
+      .module('forceHttpInTemplateFactory', [])
+      .config(function($templateFactoryProvider) {
+          $templateFactoryProvider.shouldUnsafelyUseHttp(true);
+      });
+    module('ui.router.util');
+    module('forceHttpInTemplateFactory');
+  });
+
+  it('does not restrict URL loading', inject(function($templateFactory, $httpBackend) {
+    $httpBackend.expectGET('http://evil.com/views/view.html').respond(200,  'template!');
+    $templateFactory.fromUrl('http://evil.com/views/view.html');
+    $httpBackend.flush();
+
+    $httpBackend.expectGET('data:text/html,foo').respond(200,  'template!');
+    $templateFactory.fromUrl('data:text/html,foo');
+    $httpBackend.flush();
+  }));
+});


### PR DESCRIPTION
This creates a $TemplateFactoryProvider to be able to set a global config option that forces $templateFactory to use $http (which bypasses the security checks, hence the scary name). Added tests and doc for that too. This still defaults to $http on older Angulars as expected.

Fixes the legacy part of #3193. Let me know if there's style issues or missing doc.
