### PR TITLE
Negative parameters allowed in $state

### DIFF
--- a/release/angular-ui-router.js
+++ b/release/angular-ui-router.js
@@ -1345,7 +1345,7 @@ function $UrlMatcherFactory() {
       encode: valToString,
       decode: function(val) { return parseInt(val, 10); },
       is: function(val) { return val !== undefined && val !== null && this.decode(val.toString()) === val; },
-      pattern: /\d+/
+      pattern: /-?\d+/
     },
     "bool": {
       encode: function(val) { return val ? 1 : 0; },

--- a/src/urlMatcherFactory.js
+++ b/src/urlMatcherFactory.js
@@ -611,7 +611,7 @@ function $UrlMatcherFactory() {
       encode: valToString,
       decode: function(val) { return parseInt(val, 10); },
       is: function(val) { return val !== undefined && val !== null && this.decode(val.toString()) === val; },
-      pattern: /\d+/
+      pattern: /-?\d+/
     },
     "bool": {
       encode: function(val) { return val ? 1 : 0; },

--- a/test/urlMatcherFactorySpec.js
+++ b/test/urlMatcherFactorySpec.js
@@ -599,6 +599,9 @@ describe("urlMatcherFactory", function () {
       var m = new UrlMatcher("/{foo:int}/{flag:bool}");
       expect(m.exec("/1138/1")).toEqual({ foo: 1138, flag: true });
       expect(m.format({ foo: 5, flag: true })).toBe("/5/1");
+      
+      expect(m.exec("/-1138/1")).toEqual({ foo: -1138, flag: true });
+      expect(m.format({ foo: -5, flag: true })).toBe("/-5/1");
     });
 
     it("should match built-in types with spaces", function () {


### PR DESCRIPTION
fix($state): Negative int parameters in $state allowed

Using a negative parameter in $state.go caused $rootScope:infdig errors; this is now fixed.

Closes #2422