### PR TITLE
fix(uiSref): replace angular.copy with extend

### DIFF
--- a/src/directives/stateDirectives.ts
+++ b/src/directives/stateDirectives.ts
@@ -249,10 +249,10 @@ uiSref = ['$uiRouter', '$timeout',
 
         if (ref.paramExpr) {
           scope.$watch(ref.paramExpr, function (val) {
-            rawDef.uiStateParams = angular.copy(val);
+            rawDef.uiStateParams = extend({}, val);
             update();
           }, true);
-          rawDef.uiStateParams = angular.copy(scope.$eval(ref.paramExpr));
+          rawDef.uiStateParams = extend({}, scope.$eval(ref.paramExpr));
         }
 
         update();


### PR DESCRIPTION
using angular.copy broks states with optional params containing ES6 objects like Map and Set.  The rest of ui-router seems to use extend vs angular.copy, and a deep copy shouldn't be needed here.

this fixes #3189.