### PR TITLE
use a true anonymous function inside inherit

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -13,7 +13,7 @@ var isDefined = angular.isDefined,
     toJson = angular.toJson;
 
 function inherit(parent, extra) {
-  return extend(new (extend(function() {}, { prototype: parent }))(), extra);
+  return extend(new (extend(new Function(), { prototype: parent }))(), extra);
 }
 
 function merge(dst) {


### PR DESCRIPTION
This way, objects which inherit from a parent won't appear as type `extend` but of the generic type `Object`. I've only noticed this behaviour in Chrome's console.

Before:

![image](https://cloud.githubusercontent.com/assets/5887290/24331957/e29e2040-1246-11e7-9db9-e009ea5e3c0a.png)

After:

![image](https://cloud.githubusercontent.com/assets/5887290/24331966/f7bf177c-1246-11e7-8a33-99703a57d6da.png)


