### PR TITLE
bug(directives): `data.$cfg` is passed but `getTemplate` is undefined

### DIFF
--- a/src/directives/viewDirective.ts
+++ b/src/directives/viewDirective.ts
@@ -362,6 +362,11 @@ function $ViewDirectiveFill($compile: angular.ICompileService,
         }
 
         let cfg: Ng1ViewConfig = data.$cfg || <any> { viewDecl: {}, getTemplate: noop };
+          
+        // in some cases, `data.$cfg` is passed but `getTemplate` is still undefined
+        // if thats the case, just return out. Setting `noop` does not work in this case.
+        if(!cfg.getTemplate) return;
+          
         let resolveCtx: ResolveContext = cfg.path && new ResolveContext(cfg.path);
         $element.html(cfg.getTemplate($element, resolveCtx) || initial);
         trace.traceUIViewFill(data.$uiView, $element.html());


### PR DESCRIPTION
## Issue
In some cases, `data.$cfg` is passed but `getTemplate` is still undefined...if thats the case, just return out. Setting `data.$cfg.getTemplate` to `noop` does not work in this case. I suspect this is a edge case caused by a hybrid environment.

## Solution
if `data.$cfg.getTemplate` is undefined, just return out of the loop. 

## Environment
- `ui-router` - `1.0.0-rc.1`
- `@ui-router/angular` - `1.0.0-beta.5`
- `@uirouter/core` - `5.0.0`
- `ui-router-ng1-to-ng2` - `2.0.0`