### PR TITLE
docs(CONTRIBUTING.md): fix missing label images

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,11 @@ Issues only! |
 -------------|
 Please keep in mind that the issue tracker is for *issues*. Please do *not* post an issue if you need help or support. Instead, see one of the above-mentioned forums or [IRC](irc://irc.freenode.net/#angularjs). |
 
-####Purple Labels
+#### Purple Labels
 A purple label means that **you** need to take some further action.
- - ![Not Actionable - Need Info](ngdoc_assets/incomplete.png): Your issue is not specific enough, or there is no clear action that we can take. Please clarify and refine your issue.
- - ![Plunkr Please](ngdoc_assets/example.png): Please [create a plunkr](http://bit.ly/UIR-Plunk)
- - ![StackOverflow](ngdoc_assets/so.png): We suspect your issue is really a help request, or could be answered by the community.  Please ask your question on [StackOverflow](http://stackoverflow.com/questions/ask?tags=angularjs,angular-ui-router).  If you determine that is an actual issue, please explain why.
+ - ![Not Actionable - Need Info](https://angular-ui.github.io/ui-router/ngdoc_assets/incomplete.png): Your issue is not specific enough, or there is no clear action that we can take. Please clarify and refine your issue.
+ - ![Plunkr Please](https://angular-ui.github.io/ui-router/ngdoc_assets/example.png): Please [create a plunkr](http://bit.ly/UIR-Plunk)
+ - ![StackOverflow](https://angular-ui.github.io/ui-router/ngdoc_assets/so.png): We suspect your issue is really a help request, or could be answered by the community.  Please ask your question on [StackOverflow](http://stackoverflow.com/questions/ask?tags=angularjs,angular-ui-router).  If you determine that is an actual issue, please explain why.
 
 If your issue gets labeled with purple label, no further action will be taken until you respond to the label appropriately.
 


### PR DESCRIPTION
The `Purple Labels` section of the CONTRIBUTING.md file isn't rendering properly on Github due to missing images and improperly formatted header. This PR addresses those issues.