### PR TITLE
Fix ngStrictDi support

### DIFF
--- a/src/services.ts
+++ b/src/services.ts
@@ -96,7 +96,7 @@ function runBlock($injector: IInjectorService, $q: IQService, $uiRouter: UIRoute
       .map(x => x.$$state().resolvables)
       .reduce(unnestR, [])
       .filter(x => x.deps === "deferred")
-      .forEach(resolvable => resolvable.deps = $injector.annotate(resolvable.resolveFn));
+      .forEach(resolvable => resolvable.deps = $injector.annotate(resolvable.resolveFn, $injector.strictDi));
 }
 
 // $urlRouter service and $urlRouterProvider


### PR DESCRIPTION
In some scenarios, the `$injector` would be asked to annotate without
providing it with the current `strictDi` value, making resolvables not
complain about missing annotations.

This was previously addressed in this PR: https://github.com/angular-ui/ui-router/pull/2602

Yet, it is not working, as can be seen in this plunker, that contains a resolvable without annotations and yet no error is thrown: http://plnkr.co/edit/dd6ptmrUtzPnKLmAJkCY?p=preview