### PR TITLE
fix(state): $state.is will wrongly return true

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -1266,7 +1266,7 @@ function $StateProvider(   $urlRouterProvider,   $urlMatcherFactory) {
 
       return !params || objectKeys(params).reduce(function(acc, key) {
         var paramDef = state.params[key];
-        return acc && !paramDef || paramDef.type.equals($stateParams[key], params[key]);
+        return acc && (!paramDef || paramDef.type.equals($stateParams[key], params[key]));
       }, true);
     };
 

--- a/test/stateSpec.js
+++ b/test/stateSpec.js
@@ -817,6 +817,13 @@ describe('state', function () {
       options.relative = $state.get('about.person.item');
       expect($state.is('^', undefined, options)).toBe(true);
     }));
+
+    it('should return false when the current state is passed with non matching parameters', inject(function ($state, $q) {
+      $state.transitionTo(D, {x: 'foo', y: 'qux'});
+      $q.flush();
+
+      expect($state.is(D, {x: 'bar', y: 'qux'})).toBe(false);
+    }));
   });
 
   describe('.includes()', function () {


### PR DESCRIPTION
as long as the last param matches even if the others are different.

Fixes https://github.com/angular-ui/ui-router/issues/3300

@christopherthielen 