### PR TITLE
docs(directives): Fix unescaped HTML formatting

### DIFF
--- a/src/directives/stateDirectives.ts
+++ b/src/directives/stateDirectives.ts
@@ -509,7 +509,7 @@ uiState = ['$uiRouter', '$timeout',
  * </div>
  * ```
  *
- * When the current state is "admin.roles" the "active" class will be applied to both the <div> and <a> elements.
+ * When the current state is "admin.roles" the "active" class will be applied to both the `<div>` and `<a>` elements.
  * It is important to note that the state names/globs passed to `ui-sref-active` override any state provided by a linked `ui-sref`.
  *
  * ### Notes:


### PR DESCRIPTION
This PR attempts to fix a rendering issue with the docs for [`uiSrefActive`](https://ui-router.github.io/ng1/docs/latest/modules/directives.html#uisrefactive). Due to [TypeDoc not automatically escaping HTML tags](https://github.com/TypeStrong/typedoc/issues/125), the unescaped `<div>` and `<a>` HTML tags in the docstring break the rendering. I've attempted to fix this by surrounding them with backquotes, which will hopefully render them as code per [Markdown standards](https://daringfireball.net/projects/markdown/syntax#code).

Note that I don't have any way to preview this change so I'm just hoping it works. Maybe someone familiar with TypeDoc can verify.

I am not sure if there are any other instances of this issue in the docs, this is just the one I noticed.