### PR TITLE
Add 'module' entry to allow Webpack to tree shake it

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "license": "MIT",
   "main": "release/ui-router-angularjs.js",
   "jsnext:main": "lib-esm/index.js",
+  "module": "lib-esm/index.js",
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@uirouter/core": "5.0.19"


### PR DESCRIPTION
Bundlers such as Webpack are not support `jsnext:main` entry, but do support `module`.

I've just added that entry, I've checked on my build, and webpack was able to enable module concat optimisation and tree shaking.