### PR TITLE
Move @uirouter/core to a peerDependecy rather than a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,10 +71,8 @@
   "jsnext:main": "lib-esm/index.js",
   "module": "lib-esm/index.js",
   "typings": "lib/index.d.ts",
-  "dependencies": {
-    "@uirouter/core": "6.0.3"
-  },
   "peerDependencies": {
+    "@uirouter/core": "^6.0.1",
     "angular": ">=1.2.0"
   },
   "devDependencies": {
@@ -82,6 +80,7 @@
     "@types/angular-animate": "^1.5.10",
     "@types/angular-mocks": "^1.7.0",
     "@types/jasmine": "^3.5.0",
+    "@uirouter/core": "^6.0.1",
     "@uirouter/publish-scripts": "^2.3.44",
     "dts-downlevel": "^0.3.0",
     "fork-ts-checker-webpack-plugin": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,10 +74,10 @@
   dependencies:
     "@types/node" "*"
 
-"@uirouter/core@6.0.3":
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/@uirouter/core/-/core-6.0.3.tgz#1de7a3451039e1274e7f595de2be92421c26b09c"
-  integrity sha512-ftAQw9czKUSgLFC3LwOeJP97PDQ6naHcEK0NrbWw3X/r49oQJBMRFAsz9oEKqPFPD2vUDqkvG18BZXglLp8k+Q==
+"@uirouter/core@^6.0.1":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@uirouter/core/-/core-6.0.4.tgz#fcdc75ab10f1035176acf87a27d9d27a0101ecf9"
+  integrity sha512-TQ9XOzZY+jmWKkU4993MAEBIy7Bs3kijDzj+A6RHR8gq/3UoQm3Q/l1igfao5GZyBjid7eRVeipPK14ovCYQ3g==
 
 "@uirouter/publish-scripts@^2.3.44":
   version "2.3.44"


### PR DESCRIPTION
To match the other @uirouter packages, as well as fix an issue where the
version was specified strictly causing mismatches.

BREAKING CHANGE: now needs to install peerDependency `@uirouter/core` separately

Closes angular-ui/ui-router#3794