### PR TITLE
fix: drop ng_from_import to avoid webpack warning

### DIFF
--- a/src/angular.ts
+++ b/src/angular.ts
@@ -1,5 +1,4 @@
 /** @publicapi @module ng1 */ /** */
-import * as ng_from_import from 'angular';
 /** @hidden */ declare let angular;
 /** @hidden */ const ng_from_global = angular;
-/** @hidden */ export const ng = ng_from_import && ng_from_import.module ? ng_from_import : ng_from_global;
+/** @hidden */ export const ng = ng_from_global;


### PR DESCRIPTION
due to #3721 webpack warns that export 'module' from ng_from_import cannot be found. this PR removes the import statement, which removes the warning.