### PR TITLE
chore(package): adding pkg.browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "license": "MIT",
   "main": "release/ui-router-angularjs.js",
+  "browser": "release/ui-router-angularjs.js",
   "jsnext:main": "lib-esm/index.js",
   "module": "lib-esm/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
package.json browser is recommended used for client side scripts .
https://docs.npmjs.com/cli/v7/configuring-npm/package-json#browser

Some module bundles like webpack use browser> module> main to resolve the modules according to the target , 
not having a browser field in the package.json, it always solves the pkg.module, this is a problem when you want to load browser modules that have things like windows and / or no imports (they are not supported in iifes)
